### PR TITLE
group management logic

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/GroupRole.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/GroupRole.java
@@ -1,0 +1,5 @@
+package ch.uzh.ifi.hase.soprafs26.constant;
+
+public enum GroupRole {
+	ADMIN, MEMBER
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/GroupController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/GroupController.java
@@ -1,0 +1,102 @@
+package ch.uzh.ifi.hase.soprafs26.controller;
+
+import ch.uzh.ifi.hase.soprafs26.entity.Group;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.*;
+import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
+import ch.uzh.ifi.hase.soprafs26.service.GroupService;
+import ch.uzh.ifi.hase.soprafs26.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class GroupController {
+
+	private final GroupService groupService;
+	private final UserService userService;
+
+	@Autowired
+	public GroupController(GroupService groupService, UserService userService) {
+		this.groupService = groupService;
+		this.userService = userService;
+	}
+
+	private User resolveUser(Authentication auth) {
+		return userService.getUserById(auth.getName());
+	}
+
+	@PostMapping("/groups")
+	@ResponseStatus(HttpStatus.CREATED)
+	@ResponseBody
+	public GroupGetDTO createGroup(Authentication auth, @RequestBody GroupPostDTO dto) {
+		User caller = resolveUser(auth);
+		Group group = groupService.createGroup(caller, dto.getName());
+		return DTOMapper.INSTANCE.convertEntityToGroupGetDTO(group);
+	}
+
+	@PostMapping("/groups/join")
+	@ResponseStatus(HttpStatus.OK)
+	@ResponseBody
+	public GroupGetDTO joinGroup(Authentication auth, @RequestBody GroupJoinPostDTO dto) {
+		User caller = resolveUser(auth);
+		Group group = groupService.joinGroup(caller, dto.getInviteCode());
+		return DTOMapper.INSTANCE.convertEntityToGroupGetDTO(group);
+	}
+
+	@GetMapping("/groups/my")
+	@ResponseStatus(HttpStatus.OK)
+	@ResponseBody
+	public GroupGetDTO getMyGroup(Authentication auth) {
+		Group group = groupService.getGroupOfUser(auth.getName());
+		return DTOMapper.INSTANCE.convertEntityToGroupGetDTO(group);
+	}
+
+	@PutMapping("/groups/my")
+	@ResponseStatus(HttpStatus.OK)
+	@ResponseBody
+	public GroupGetDTO updateGroup(Authentication auth, @RequestBody GroupPostDTO dto) {
+		User caller = resolveUser(auth);
+		Group group = groupService.updateGroupName(caller, dto.getName());
+		return DTOMapper.INSTANCE.convertEntityToGroupGetDTO(group);
+	}
+
+	@DeleteMapping("/groups/my")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void deleteGroup(Authentication auth) {
+		User caller = resolveUser(auth);
+		groupService.deleteGroup(caller);
+	}
+
+	@PostMapping("/groups/my/invite-code")
+	@ResponseStatus(HttpStatus.OK)
+	@ResponseBody
+	public GroupGetDTO regenerateInviteCode(Authentication auth) {
+		User caller = resolveUser(auth);
+		Group group = groupService.regenerateInviteCode(caller);
+		return DTOMapper.INSTANCE.convertEntityToGroupGetDTO(group);
+	}
+
+	@PutMapping("/groups/my/members/{userID}")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void updateMemberRole(Authentication auth, @PathVariable String userID,
+			@RequestBody GroupRolePutDTO dto) {
+		User caller = resolveUser(auth);
+		groupService.updateMemberRole(caller, userID, dto.getRole());
+	}
+
+	@DeleteMapping("/groups/my/members/{userID}")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void removeMember(Authentication auth, @PathVariable String userID) {
+		User caller = resolveUser(auth);
+		groupService.removeMember(caller, userID);
+	}
+
+	@DeleteMapping("/groups/my/members/me")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void leaveGroup(Authentication auth) {
+		User caller = resolveUser(auth);
+		groupService.leaveGroup(caller);
+	}
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/GroupController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/GroupController.java
@@ -45,7 +45,7 @@ public class GroupController {
 		return DTOMapper.INSTANCE.convertEntityToGroupGetDTO(group);
 	}
 
-	@GetMapping("/groups/my")
+	@GetMapping("/groups/me")
 	@ResponseStatus(HttpStatus.OK)
 	@ResponseBody
 	public GroupGetDTO getMyGroup(Authentication auth) {
@@ -53,7 +53,7 @@ public class GroupController {
 		return DTOMapper.INSTANCE.convertEntityToGroupGetDTO(group);
 	}
 
-	@PutMapping("/groups/my")
+	@PutMapping("/groups/me")
 	@ResponseStatus(HttpStatus.OK)
 	@ResponseBody
 	public GroupGetDTO updateGroup(Authentication auth, @RequestBody GroupPostDTO dto) {
@@ -62,14 +62,14 @@ public class GroupController {
 		return DTOMapper.INSTANCE.convertEntityToGroupGetDTO(group);
 	}
 
-	@DeleteMapping("/groups/my")
+	@DeleteMapping("/groups/me")
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	public void deleteGroup(Authentication auth) {
 		User caller = resolveUser(auth);
 		groupService.deleteGroup(caller);
 	}
 
-	@PostMapping("/groups/my/invite-code")
+	@PostMapping("/groups/me/invite-code")
 	@ResponseStatus(HttpStatus.OK)
 	@ResponseBody
 	public GroupGetDTO regenerateInviteCode(Authentication auth) {
@@ -78,7 +78,7 @@ public class GroupController {
 		return DTOMapper.INSTANCE.convertEntityToGroupGetDTO(group);
 	}
 
-	@PutMapping("/groups/my/members/{userID}")
+	@PutMapping("/groups/me/members/{userID}")
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	public void updateMemberRole(Authentication auth, @PathVariable String userID,
 			@RequestBody GroupRolePutDTO dto) {
@@ -86,14 +86,14 @@ public class GroupController {
 		groupService.updateMemberRole(caller, userID, dto.getRole());
 	}
 
-	@DeleteMapping("/groups/my/members/{userID}")
+	@DeleteMapping("/groups/me/members/{userID}")
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	public void removeMember(Authentication auth, @PathVariable String userID) {
 		User caller = resolveUser(auth);
 		groupService.removeMember(caller, userID);
 	}
 
-	@DeleteMapping("/groups/my/members/me")
+	@DeleteMapping("/groups/me/members/me")
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	public void leaveGroup(Authentication auth) {
 		User caller = resolveUser(auth);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Group.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Group.java
@@ -1,0 +1,48 @@
+package ch.uzh.ifi.hase.soprafs26.entity;
+
+import jakarta.persistence.*;
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "user_groups")
+public class Group implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	@Column(nullable = false)
+	private String name;
+
+	@Column(nullable = false, unique = true)
+	private String inviteCode;
+
+	@Column(nullable = false)
+	private Instant createdAt;
+
+	@OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<GroupMembership> memberships = new ArrayList<>();
+
+	@PrePersist
+	protected void onCreate() {
+		if (this.createdAt == null) {
+			this.createdAt = Instant.now();
+		}
+	}
+
+	public Long getId() { return id; }
+	public void setId(Long id) { this.id = id; }
+	public String getName() { return name; }
+	public void setName(String name) { this.name = name; }
+	public String getInviteCode() { return inviteCode; }
+	public void setInviteCode(String inviteCode) { this.inviteCode = inviteCode; }
+	public Instant getCreatedAt() { return createdAt; }
+	public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+	public List<GroupMembership> getMemberships() { return memberships; }
+	public void setMemberships(List<GroupMembership> memberships) { this.memberships = memberships; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/GroupMembership.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/GroupMembership.java
@@ -1,0 +1,53 @@
+package ch.uzh.ifi.hase.soprafs26.entity;
+
+import ch.uzh.ifi.hase.soprafs26.constant.GroupRole;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import java.io.Serializable;
+import java.time.Instant;
+
+@Entity
+@Table(name = "group_memberships",
+		uniqueConstraints = @UniqueConstraint(columnNames = "user_id"))
+public class GroupMembership implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "group_id", nullable = false)
+	@JsonIgnore
+	private Group group;
+
+	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
+	private GroupRole role;
+
+	@Column(nullable = false)
+	private Instant joinedAt;
+
+	@PrePersist
+	protected void onCreate() {
+		if (this.joinedAt == null) {
+			this.joinedAt = Instant.now();
+		}
+	}
+
+	public Long getId() { return id; }
+	public void setId(Long id) { this.id = id; }
+	public User getUser() { return user; }
+	public void setUser(User user) { this.user = user; }
+	public Group getGroup() { return group; }
+	public void setGroup(Group group) { this.group = group; }
+	public GroupRole getRole() { return role; }
+	public void setRole(GroupRole role) { this.role = role; }
+	public Instant getJoinedAt() { return joinedAt; }
+	public void setJoinedAt(Instant joinedAt) { this.joinedAt = joinedAt; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/GroupMembershipRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/GroupMembershipRepository.java
@@ -1,0 +1,15 @@
+package ch.uzh.ifi.hase.soprafs26.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import ch.uzh.ifi.hase.soprafs26.entity.GroupMembership;
+import java.util.List;
+import java.util.Optional;
+
+@Repository("groupMembershipRepository")
+public interface GroupMembershipRepository extends JpaRepository<GroupMembership, Long> {
+	Optional<GroupMembership> findByUserUserID(String userID);
+	Optional<GroupMembership> findByUserUserIDAndGroupId(String userID, Long groupId);
+	List<GroupMembership> findByGroupId(Long groupId);
+	long countByGroupId(Long groupId);
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/GroupRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/GroupRepository.java
@@ -1,0 +1,11 @@
+package ch.uzh.ifi.hase.soprafs26.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import ch.uzh.ifi.hase.soprafs26.entity.Group;
+import java.util.Optional;
+
+@Repository("groupRepository")
+public interface GroupRepository extends JpaRepository<Group, Long> {
+	Optional<Group> findByInviteCode(String inviteCode);
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GroupGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GroupGetDTO.java
@@ -1,0 +1,23 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+public class GroupGetDTO {
+	private Long id;
+	private String name;
+	private String inviteCode;
+	private Instant createdAt;
+	private List<GroupMemberGetDTO> members;
+
+	public Long getId() { return id; }
+	public void setId(Long id) { this.id = id; }
+	public String getName() { return name; }
+	public void setName(String name) { this.name = name; }
+	public String getInviteCode() { return inviteCode; }
+	public void setInviteCode(String inviteCode) { this.inviteCode = inviteCode; }
+	public Instant getCreatedAt() { return createdAt; }
+	public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+	public List<GroupMemberGetDTO> getMembers() { return members; }
+	public void setMembers(List<GroupMemberGetDTO> members) { this.members = members; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GroupJoinPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GroupJoinPostDTO.java
@@ -1,0 +1,7 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+public class GroupJoinPostDTO {
+	private String inviteCode;
+	public String getInviteCode() { return inviteCode; }
+	public void setInviteCode(String inviteCode) { this.inviteCode = inviteCode; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GroupMemberGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GroupMemberGetDTO.java
@@ -1,0 +1,20 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+import ch.uzh.ifi.hase.soprafs26.constant.GroupRole;
+import java.time.Instant;
+
+public class GroupMemberGetDTO {
+	private String userID;
+	private String username;
+	private GroupRole role;
+	private Instant joinedAt;
+
+	public String getUserID() { return userID; }
+	public void setUserID(String userID) { this.userID = userID; }
+	public String getUsername() { return username; }
+	public void setUsername(String username) { this.username = username; }
+	public GroupRole getRole() { return role; }
+	public void setRole(GroupRole role) { this.role = role; }
+	public Instant getJoinedAt() { return joinedAt; }
+	public void setJoinedAt(Instant joinedAt) { this.joinedAt = joinedAt; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GroupPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GroupPostDTO.java
@@ -1,0 +1,7 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+public class GroupPostDTO {
+	private String name;
+	public String getName() { return name; }
+	public void setName(String name) { this.name = name; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GroupRolePutDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GroupRolePutDTO.java
@@ -1,0 +1,9 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+import ch.uzh.ifi.hase.soprafs26.constant.GroupRole;
+
+public class GroupRolePutDTO {
+	private GroupRole role;
+	public GroupRole getRole() { return role; }
+	public void setRole(GroupRole role) { this.role = role; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -3,17 +3,17 @@ package ch.uzh.ifi.hase.soprafs26.rest.mapper;
 import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
 
+import ch.uzh.ifi.hase.soprafs26.entity.Group;
+import ch.uzh.ifi.hase.soprafs26.entity.GroupMembership;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.LoginGetDTO;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.LoginPostDTO;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.RegisterPostDTO;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.UserGetDTO;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.UserPostDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.*;
 
 @Mapper
 public interface DTOMapper {
 
 	DTOMapper INSTANCE = Mappers.getMapper(DTOMapper.class);
+
+	// ─── User mappings (from main) ──────────────────
 
 	@BeanMapping(ignoreByDefault = true)
 	@Mapping(source = "email", target = "email")
@@ -43,7 +43,18 @@ public interface DTOMapper {
 	@Mapping(source = "status", target = "status")
 	UserGetDTO convertEntityToUserGetDTO(User user);
 
-    @Mapping(source = "userID", target = "userID")
-    @Mapping(source = "token", target = "token")
-    LoginGetDTO convertEntityToLoginGetDTO(User user);
+	@Mapping(source = "userID", target = "userID")
+	@Mapping(source = "token", target = "token")
+	LoginGetDTO convertEntityToLoginGetDTO(User user);
+
+	// ─── Group mappings ─────────────────────────────
+
+	@Mapping(source = "memberships", target = "members")
+	GroupGetDTO convertEntityToGroupGetDTO(Group group);
+
+	@Mapping(source = "user.userID", target = "userID")
+	@Mapping(source = "user.username", target = "username")
+	@Mapping(source = "role", target = "role")
+	@Mapping(source = "joinedAt", target = "joinedAt")
+	GroupMemberGetDTO convertEntityToGroupMemberGetDTO(GroupMembership membership);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GroupService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GroupService.java
@@ -1,0 +1,223 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import ch.uzh.ifi.hase.soprafs26.constant.GroupRole;
+import ch.uzh.ifi.hase.soprafs26.entity.Group;
+import ch.uzh.ifi.hase.soprafs26.entity.GroupMembership;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.repository.GroupMembershipRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.GroupRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.security.SecureRandom;
+import java.util.List;
+
+@Service
+@Transactional
+public class GroupService {
+
+	private final Logger log = LoggerFactory.getLogger(GroupService.class);
+
+	private static final int MAX_MEMBERS = 100;
+	private static final int INVITE_CODE_LENGTH = 8;
+	private static final String INVITE_CODE_CHARS = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+	private static final SecureRandom RANDOM = new SecureRandom();
+
+	private final GroupRepository groupRepository;
+	private final GroupMembershipRepository membershipRepository;
+
+	@Autowired
+	public GroupService(GroupRepository groupRepository,
+			GroupMembershipRepository membershipRepository) {
+		this.groupRepository = groupRepository;
+		this.membershipRepository = membershipRepository;
+	}
+
+	public Group createGroup(User creator, String groupName) {
+		ensureUserNotInGroup(creator.getUserID());
+
+		Group group = new Group();
+		group.setName(groupName);
+		group.setInviteCode(generateUniqueInviteCode());
+		group = groupRepository.save(group);
+		groupRepository.flush();
+
+		GroupMembership membership = new GroupMembership();
+		membership.setUser(creator);
+		membership.setGroup(group);
+		membership.setRole(GroupRole.ADMIN);
+		membershipRepository.save(membership);
+		membershipRepository.flush();
+
+		log.debug("Created group '{}' (id={}) with admin userID={}", groupName, group.getId(), creator.getUserID());
+		return group;
+	}
+
+	public Group joinGroup(User joiner, String inviteCode) {
+		ensureUserNotInGroup(joiner.getUserID());
+
+		Group group = groupRepository.findByInviteCode(inviteCode)
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+						"No group found with that invite code"));
+
+		long memberCount = membershipRepository.countByGroupId(group.getId());
+		if (memberCount >= MAX_MEMBERS) {
+			throw new ResponseStatusException(HttpStatus.CONFLICT,
+					"Group has reached the maximum of " + MAX_MEMBERS + " members");
+		}
+
+		GroupMembership membership = new GroupMembership();
+		membership.setUser(joiner);
+		membership.setGroup(group);
+		membership.setRole(GroupRole.MEMBER);
+		membershipRepository.save(membership);
+		membershipRepository.flush();
+
+		log.debug("User {} joined group {} via invite code", joiner.getUserID(), group.getId());
+		return group;
+	}
+
+	public Group getGroupOfUser(String userID) {
+		GroupMembership membership = membershipRepository.findByUserUserID(userID)
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+						"You are not a member of any group"));
+		return membership.getGroup();
+	}
+
+	public Group updateGroupName(User admin, String newName) {
+		GroupMembership membership = getAdminMembership(admin.getUserID());
+		Group group = membership.getGroup();
+		group.setName(newName);
+		groupRepository.save(group);
+		groupRepository.flush();
+		return group;
+	}
+
+	public Group regenerateInviteCode(User admin) {
+		GroupMembership membership = getAdminMembership(admin.getUserID());
+		Group group = membership.getGroup();
+		group.setInviteCode(generateUniqueInviteCode());
+		groupRepository.save(group);
+		groupRepository.flush();
+		return group;
+	}
+
+	public void updateMemberRole(User admin, String targetUserID, GroupRole newRole) {
+		GroupMembership adminMembership = getAdminMembership(admin.getUserID());
+		Long groupId = adminMembership.getGroup().getId();
+
+		GroupMembership targetMembership = membershipRepository.findByUserUserIDAndGroupId(targetUserID, groupId)
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+						"Target user is not a member of your group"));
+
+		if (targetMembership.getRole() == GroupRole.ADMIN && newRole == GroupRole.MEMBER) {
+			if (countAdmins(groupId) <= 1) {
+				throw new ResponseStatusException(HttpStatus.CONFLICT,
+						"Cannot demote the only admin. Promote another member first.");
+			}
+		}
+
+		targetMembership.setRole(newRole);
+		membershipRepository.save(targetMembership);
+		membershipRepository.flush();
+	}
+
+	public void removeMember(User admin, String targetUserID) {
+		GroupMembership adminMembership = getAdminMembership(admin.getUserID());
+		Long groupId = adminMembership.getGroup().getId();
+
+		GroupMembership targetMembership = membershipRepository.findByUserUserIDAndGroupId(targetUserID, groupId)
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+						"Target user is not a member of your group"));
+
+		if (targetMembership.getRole() == GroupRole.ADMIN) {
+			if (countAdmins(groupId) <= 1) {
+				throw new ResponseStatusException(HttpStatus.CONFLICT,
+						"Cannot remove the only admin. Delete the group instead, or promote another member first.");
+			}
+		}
+
+		membershipRepository.delete(targetMembership);
+		membershipRepository.flush();
+	}
+
+	public void leaveGroup(User user) {
+		GroupMembership membership = membershipRepository.findByUserUserID(user.getUserID())
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+						"You are not a member of any group"));
+
+		if (membership.getRole() == GroupRole.ADMIN) {
+			long adminCount = countAdmins(membership.getGroup().getId());
+			if (adminCount <= 1) {
+				long totalMembers = membershipRepository.countByGroupId(membership.getGroup().getId());
+				if (totalMembers > 1) {
+					throw new ResponseStatusException(HttpStatus.CONFLICT,
+							"You are the only admin. Promote another member to admin before leaving, or delete the group.");
+				}
+				deleteGroupInternal(membership.getGroup());
+				return;
+			}
+		}
+
+		membershipRepository.delete(membership);
+		membershipRepository.flush();
+	}
+
+	public void deleteGroup(User admin) {
+		GroupMembership membership = getAdminMembership(admin.getUserID());
+		deleteGroupInternal(membership.getGroup());
+	}
+
+	// ─── helpers ───────────────────────────────────────────────
+
+	private void deleteGroupInternal(Group group) {
+		groupRepository.delete(group);
+		groupRepository.flush();
+		log.debug("Deleted group {}", group.getId());
+	}
+
+	private void ensureUserNotInGroup(String userID) {
+		if (membershipRepository.findByUserUserID(userID).isPresent()) {
+			throw new ResponseStatusException(HttpStatus.CONFLICT,
+					"You are already a member of a group. Leave your current group first.");
+		}
+	}
+
+	private GroupMembership getAdminMembership(String userID) {
+		GroupMembership membership = membershipRepository.findByUserUserID(userID)
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+						"You are not a member of any group"));
+		if (membership.getRole() != GroupRole.ADMIN) {
+			throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+					"Only group admins can perform this action");
+		}
+		return membership;
+	}
+
+	private long countAdmins(Long groupId) {
+		return membershipRepository.findByGroupId(groupId).stream()
+				.filter(m -> m.getRole() == GroupRole.ADMIN)
+				.count();
+	}
+
+	private String generateUniqueInviteCode() {
+		String code;
+		do {
+			code = generateRandomCode();
+		} while (groupRepository.findByInviteCode(code).isPresent());
+		return code;
+	}
+
+	private String generateRandomCode() {
+		StringBuilder sb = new StringBuilder(INVITE_CODE_LENGTH);
+		for (int i = 0; i < INVITE_CODE_LENGTH; i++) {
+			sb.append(INVITE_CODE_CHARS.charAt(RANDOM.nextInt(INVITE_CODE_CHARS.length())));
+		}
+		return sb.toString();
+	}
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GroupServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GroupServiceTest.java
@@ -1,0 +1,224 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import ch.uzh.ifi.hase.soprafs26.constant.GroupRole;
+import ch.uzh.ifi.hase.soprafs26.entity.Group;
+import ch.uzh.ifi.hase.soprafs26.entity.GroupMembership;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.repository.GroupMembershipRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.GroupRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class GroupServiceTest {
+
+	@Mock
+	private GroupRepository groupRepository;
+	@Mock
+	private GroupMembershipRepository membershipRepository;
+
+	@InjectMocks
+	private GroupService groupService;
+
+	private User testUser;
+	private User testUser2;
+	private Group testGroup;
+	private GroupMembership adminMembership;
+
+	@BeforeEach
+	public void setup() {
+		MockitoAnnotations.openMocks(this);
+
+		testUser = new User();
+		testUser.setUserID("user-1");
+		testUser.setUsername("admin");
+		testUser.setToken("admin-token");
+
+		testUser2 = new User();
+		testUser2.setUserID("user-2");
+		testUser2.setUsername("member");
+		testUser2.setToken("member-token");
+
+		testGroup = new Group();
+		testGroup.setId(1L);
+		testGroup.setName("Test Group");
+		testGroup.setInviteCode("ABC12345");
+		testGroup.setMemberships(new ArrayList<>());
+
+		adminMembership = new GroupMembership();
+		adminMembership.setId(1L);
+		adminMembership.setUser(testUser);
+		adminMembership.setGroup(testGroup);
+		adminMembership.setRole(GroupRole.ADMIN);
+	}
+
+	@Test
+	public void createGroup_validInput_success() {
+		when(membershipRepository.findByUserUserID(testUser.getUserID())).thenReturn(Optional.empty());
+		when(groupRepository.save(any(Group.class))).thenAnswer(i -> { Group g = i.getArgument(0); g.setId(1L); return g; });
+		when(membershipRepository.save(any(GroupMembership.class))).thenAnswer(i -> i.getArgument(0));
+		when(groupRepository.findByInviteCode(any())).thenReturn(Optional.empty());
+
+		Group created = groupService.createGroup(testUser, "My Group");
+		assertNotNull(created);
+		assertEquals("My Group", created.getName());
+	}
+
+	@Test
+	public void createGroup_alreadyInGroup_throwsConflict() {
+		when(membershipRepository.findByUserUserID(testUser.getUserID())).thenReturn(Optional.of(adminMembership));
+		assertThrows(ResponseStatusException.class, () -> groupService.createGroup(testUser, "X"));
+	}
+
+	@Test
+	public void joinGroup_validCode_success() {
+		when(membershipRepository.findByUserUserID(testUser2.getUserID())).thenReturn(Optional.empty());
+		when(groupRepository.findByInviteCode("ABC12345")).thenReturn(Optional.of(testGroup));
+		when(membershipRepository.countByGroupId(1L)).thenReturn(1L);
+		when(membershipRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+		Group joined = groupService.joinGroup(testUser2, "ABC12345");
+		assertEquals(1L, joined.getId());
+	}
+
+	@Test
+	public void joinGroup_invalidCode_throwsNotFound() {
+		when(membershipRepository.findByUserUserID(testUser2.getUserID())).thenReturn(Optional.empty());
+		when(groupRepository.findByInviteCode("BAD")).thenReturn(Optional.empty());
+		assertThrows(ResponseStatusException.class, () -> groupService.joinGroup(testUser2, "BAD"));
+	}
+
+	@Test
+	public void joinGroup_groupFull_throwsConflict() {
+		when(membershipRepository.findByUserUserID(testUser2.getUserID())).thenReturn(Optional.empty());
+		when(groupRepository.findByInviteCode("ABC12345")).thenReturn(Optional.of(testGroup));
+		when(membershipRepository.countByGroupId(1L)).thenReturn(100L);
+		assertThrows(ResponseStatusException.class, () -> groupService.joinGroup(testUser2, "ABC12345"));
+	}
+
+	@Test
+	public void getGroupOfUser_isMember_returnsGroup() {
+		when(membershipRepository.findByUserUserID("user-1")).thenReturn(Optional.of(adminMembership));
+		assertEquals(1L, groupService.getGroupOfUser("user-1").getId());
+	}
+
+	@Test
+	public void getGroupOfUser_notInGroup_throws() {
+		when(membershipRepository.findByUserUserID("user-1")).thenReturn(Optional.empty());
+		assertThrows(ResponseStatusException.class, () -> groupService.getGroupOfUser("user-1"));
+	}
+
+	@Test
+	public void updateGroupName_asAdmin_success() {
+		when(membershipRepository.findByUserUserID("user-1")).thenReturn(Optional.of(adminMembership));
+		when(groupRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+		assertEquals("New", groupService.updateGroupName(testUser, "New").getName());
+	}
+
+	@Test
+	public void updateGroupName_asMember_throwsForbidden() {
+		GroupMembership m = new GroupMembership();
+		m.setUser(testUser2); m.setGroup(testGroup); m.setRole(GroupRole.MEMBER);
+		when(membershipRepository.findByUserUserID("user-2")).thenReturn(Optional.of(m));
+		assertThrows(ResponseStatusException.class, () -> groupService.updateGroupName(testUser2, "New"));
+	}
+
+	@Test
+	public void updateMemberRole_promoteToAdmin_success() {
+		GroupMembership m = new GroupMembership();
+		m.setUser(testUser2); m.setGroup(testGroup); m.setRole(GroupRole.MEMBER);
+		when(membershipRepository.findByUserUserID("user-1")).thenReturn(Optional.of(adminMembership));
+		when(membershipRepository.findByUserUserIDAndGroupId("user-2", 1L)).thenReturn(Optional.of(m));
+		when(membershipRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+		groupService.updateMemberRole(testUser, "user-2", GroupRole.ADMIN);
+		assertEquals(GroupRole.ADMIN, m.getRole());
+	}
+
+	@Test
+	public void updateMemberRole_demoteOnlyAdmin_throws() {
+		when(membershipRepository.findByUserUserID("user-1")).thenReturn(Optional.of(adminMembership));
+		when(membershipRepository.findByUserUserIDAndGroupId("user-1", 1L)).thenReturn(Optional.of(adminMembership));
+		when(membershipRepository.findByGroupId(1L)).thenReturn(Collections.singletonList(adminMembership));
+		assertThrows(ResponseStatusException.class, () -> groupService.updateMemberRole(testUser, "user-1", GroupRole.MEMBER));
+	}
+
+	@Test
+	public void removeMember_success() {
+		GroupMembership m = new GroupMembership();
+		m.setUser(testUser2); m.setGroup(testGroup); m.setRole(GroupRole.MEMBER);
+		when(membershipRepository.findByUserUserID("user-1")).thenReturn(Optional.of(adminMembership));
+		when(membershipRepository.findByUserUserIDAndGroupId("user-2", 1L)).thenReturn(Optional.of(m));
+		groupService.removeMember(testUser, "user-2");
+		verify(membershipRepository).delete(m);
+	}
+
+	@Test
+	public void removeMember_soleAdmin_throws() {
+		when(membershipRepository.findByUserUserID("user-1")).thenReturn(Optional.of(adminMembership));
+		when(membershipRepository.findByUserUserIDAndGroupId("user-1", 1L)).thenReturn(Optional.of(adminMembership));
+		when(membershipRepository.findByGroupId(1L)).thenReturn(Collections.singletonList(adminMembership));
+		assertThrows(ResponseStatusException.class, () -> groupService.removeMember(testUser, "user-1"));
+	}
+
+	@Test
+	public void leaveGroup_asMember_success() {
+		GroupMembership m = new GroupMembership();
+		m.setUser(testUser2); m.setGroup(testGroup); m.setRole(GroupRole.MEMBER);
+		when(membershipRepository.findByUserUserID("user-2")).thenReturn(Optional.of(m));
+		groupService.leaveGroup(testUser2);
+		verify(membershipRepository).delete(m);
+	}
+
+	@Test
+	public void leaveGroup_soleAdminSoleMember_deletesGroup() {
+		when(membershipRepository.findByUserUserID("user-1")).thenReturn(Optional.of(adminMembership));
+		when(membershipRepository.findByGroupId(1L)).thenReturn(Collections.singletonList(adminMembership));
+		when(membershipRepository.countByGroupId(1L)).thenReturn(1L);
+		groupService.leaveGroup(testUser);
+		verify(groupRepository).delete(testGroup);
+	}
+
+	@Test
+	public void leaveGroup_soleAdminWithMembers_throws() {
+		GroupMembership m = new GroupMembership();
+		m.setUser(testUser2); m.setGroup(testGroup); m.setRole(GroupRole.MEMBER);
+		when(membershipRepository.findByUserUserID("user-1")).thenReturn(Optional.of(adminMembership));
+		when(membershipRepository.findByGroupId(1L)).thenReturn(List.of(adminMembership, m));
+		when(membershipRepository.countByGroupId(1L)).thenReturn(2L);
+		assertThrows(ResponseStatusException.class, () -> groupService.leaveGroup(testUser));
+	}
+
+	@Test
+	public void deleteGroup_asAdmin_success() {
+		when(membershipRepository.findByUserUserID("user-1")).thenReturn(Optional.of(adminMembership));
+		groupService.deleteGroup(testUser);
+		verify(groupRepository).delete(testGroup);
+	}
+
+	@Test
+	public void deleteGroup_asMember_throws() {
+		GroupMembership m = new GroupMembership();
+		m.setUser(testUser2); m.setGroup(testGroup); m.setRole(GroupRole.MEMBER);
+		when(membershipRepository.findByUserUserID("user-2")).thenReturn(Optional.of(m));
+		assertThrows(ResponseStatusException.class, () -> groupService.deleteGroup(testUser2));
+	}
+
+	@Test
+	public void regenerateInviteCode_asAdmin_success() {
+		when(membershipRepository.findByUserUserID("user-1")).thenReturn(Optional.of(adminMembership));
+		when(groupRepository.findByInviteCode(any())).thenReturn(Optional.empty());
+		when(groupRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+		Group result = groupService.regenerateInviteCode(testUser);
+		assertNotNull(result.getInviteCode());
+	}
+}


### PR DESCRIPTION
Group management logic implementation with the following design decisions made:

- Each user can be a member of max 1 group (! for MVP should be fine based on the logic that each person lives in 1 household)
- Group have roles Admin and Member; person creating the group is automatically Admin;
- Admin can fully manage the group and delete/accept/change roles of members; It's impossible to delete the admin if he's the only member => group has to be deleted then
- Group can consist of up to 100 members (to have some limit and prevent overflows)
- invite to group is happening by sending code to join
- group has 1 shopping list and 1 pantry list which are created automatically upon group creation