### PR TITLE
Pantry management v2

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/Application.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/Application.java
@@ -12,7 +12,6 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @RestController
 @SpringBootApplication
 public class Application {
-
 	public static void main(String[] args) {
 		SpringApplication.run(Application.class, args);
 	}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/GroupRole.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/GroupRole.java
@@ -1,0 +1,5 @@
+package ch.uzh.ifi.hase.soprafs26.constant;
+
+public enum GroupRole {
+	ADMIN, MEMBER
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/Unit.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/Unit.java
@@ -1,0 +1,5 @@
+package ch.uzh.ifi.hase.soprafs26.constant;
+
+public enum Unit {
+	GRAM, KILOGRAM, MILLILITER, CENTILITER, LITER, PIECE, TABLESPOON, TEASPOON, CUP
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/GroupController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/GroupController.java
@@ -1,0 +1,102 @@
+package ch.uzh.ifi.hase.soprafs26.controller;
+
+import ch.uzh.ifi.hase.soprafs26.entity.Group;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.*;
+import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
+import ch.uzh.ifi.hase.soprafs26.service.GroupService;
+import ch.uzh.ifi.hase.soprafs26.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class GroupController {
+
+	private final GroupService groupService;
+	private final UserService userService;
+
+	@Autowired
+	public GroupController(GroupService groupService, UserService userService) {
+		this.groupService = groupService;
+		this.userService = userService;
+	}
+
+	private User resolveUser(Authentication auth) {
+		return userService.getUserById(auth.getName());
+	}
+
+	@PostMapping("/groups")
+	@ResponseStatus(HttpStatus.CREATED)
+	@ResponseBody
+	public GroupGetDTO createGroup(Authentication auth, @RequestBody GroupPostDTO dto) {
+		User caller = resolveUser(auth);
+		Group group = groupService.createGroup(caller, dto.getName());
+		return DTOMapper.INSTANCE.convertEntityToGroupGetDTO(group);
+	}
+
+	@PostMapping("/groups/join")
+	@ResponseStatus(HttpStatus.OK)
+	@ResponseBody
+	public GroupGetDTO joinGroup(Authentication auth, @RequestBody GroupJoinPostDTO dto) {
+		User caller = resolveUser(auth);
+		Group group = groupService.joinGroup(caller, dto.getInviteCode());
+		return DTOMapper.INSTANCE.convertEntityToGroupGetDTO(group);
+	}
+
+	@GetMapping("/groups/my")
+	@ResponseStatus(HttpStatus.OK)
+	@ResponseBody
+	public GroupGetDTO getMyGroup(Authentication auth) {
+		Group group = groupService.getGroupOfUser(auth.getName());
+		return DTOMapper.INSTANCE.convertEntityToGroupGetDTO(group);
+	}
+
+	@PutMapping("/groups/my")
+	@ResponseStatus(HttpStatus.OK)
+	@ResponseBody
+	public GroupGetDTO updateGroup(Authentication auth, @RequestBody GroupPostDTO dto) {
+		User caller = resolveUser(auth);
+		Group group = groupService.updateGroupName(caller, dto.getName());
+		return DTOMapper.INSTANCE.convertEntityToGroupGetDTO(group);
+	}
+
+	@DeleteMapping("/groups/my")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void deleteGroup(Authentication auth) {
+		User caller = resolveUser(auth);
+		groupService.deleteGroup(caller);
+	}
+
+	@PostMapping("/groups/my/invite-code")
+	@ResponseStatus(HttpStatus.OK)
+	@ResponseBody
+	public GroupGetDTO regenerateInviteCode(Authentication auth) {
+		User caller = resolveUser(auth);
+		Group group = groupService.regenerateInviteCode(caller);
+		return DTOMapper.INSTANCE.convertEntityToGroupGetDTO(group);
+	}
+
+	@PutMapping("/groups/my/members/{userID}")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void updateMemberRole(Authentication auth, @PathVariable String userID,
+			@RequestBody GroupRolePutDTO dto) {
+		User caller = resolveUser(auth);
+		groupService.updateMemberRole(caller, userID, dto.getRole());
+	}
+
+	@DeleteMapping("/groups/my/members/{userID}")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void removeMember(Authentication auth, @PathVariable String userID) {
+		User caller = resolveUser(auth);
+		groupService.removeMember(caller, userID);
+	}
+
+	@DeleteMapping("/groups/my/members/me")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void leaveGroup(Authentication auth) {
+		User caller = resolveUser(auth);
+		groupService.leaveGroup(caller);
+	}
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/GroupController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/GroupController.java
@@ -45,7 +45,7 @@ public class GroupController {
 		return DTOMapper.INSTANCE.convertEntityToGroupGetDTO(group);
 	}
 
-	@GetMapping("/groups/my")
+	@GetMapping("/groups/me")
 	@ResponseStatus(HttpStatus.OK)
 	@ResponseBody
 	public GroupGetDTO getMyGroup(Authentication auth) {
@@ -53,7 +53,7 @@ public class GroupController {
 		return DTOMapper.INSTANCE.convertEntityToGroupGetDTO(group);
 	}
 
-	@PutMapping("/groups/my")
+	@PutMapping("/groups/me")
 	@ResponseStatus(HttpStatus.OK)
 	@ResponseBody
 	public GroupGetDTO updateGroup(Authentication auth, @RequestBody GroupPostDTO dto) {
@@ -62,14 +62,14 @@ public class GroupController {
 		return DTOMapper.INSTANCE.convertEntityToGroupGetDTO(group);
 	}
 
-	@DeleteMapping("/groups/my")
+	@DeleteMapping("/groups/me")
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	public void deleteGroup(Authentication auth) {
 		User caller = resolveUser(auth);
 		groupService.deleteGroup(caller);
 	}
 
-	@PostMapping("/groups/my/invite-code")
+	@PostMapping("/groups/me/invite-code")
 	@ResponseStatus(HttpStatus.OK)
 	@ResponseBody
 	public GroupGetDTO regenerateInviteCode(Authentication auth) {
@@ -78,7 +78,7 @@ public class GroupController {
 		return DTOMapper.INSTANCE.convertEntityToGroupGetDTO(group);
 	}
 
-	@PutMapping("/groups/my/members/{userID}")
+	@PutMapping("/groups/me/members/{userID}")
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	public void updateMemberRole(Authentication auth, @PathVariable String userID,
 			@RequestBody GroupRolePutDTO dto) {
@@ -86,14 +86,14 @@ public class GroupController {
 		groupService.updateMemberRole(caller, userID, dto.getRole());
 	}
 
-	@DeleteMapping("/groups/my/members/{userID}")
+	@DeleteMapping("/groups/me/members/{userID}")
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	public void removeMember(Authentication auth, @PathVariable String userID) {
 		User caller = resolveUser(auth);
 		groupService.removeMember(caller, userID);
 	}
 
-	@DeleteMapping("/groups/my/members/me")
+	@DeleteMapping("/groups/me/members/me")
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	public void leaveGroup(Authentication auth) {
 		User caller = resolveUser(auth);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/IngredientController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/IngredientController.java
@@ -1,0 +1,40 @@
+package ch.uzh.ifi.hase.soprafs26.controller;
+
+import ch.uzh.ifi.hase.soprafs26.entity.Ingredient;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.IngredientGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.IngredientPostDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
+import ch.uzh.ifi.hase.soprafs26.service.IngredientService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+public class IngredientController {
+
+	private final IngredientService ingredientService;
+
+	public IngredientController(IngredientService ingredientService) {
+		this.ingredientService = ingredientService;
+	}
+
+	@GetMapping("/ingredients")
+	@ResponseStatus(HttpStatus.OK)
+	@ResponseBody
+	public List<IngredientGetDTO> getIngredients() {
+		return ingredientService.getIngredients().stream()
+				.map(DTOMapper.INSTANCE::convertEntityToIngredientGetDTO)
+				.toList();
+	}
+
+	@PostMapping("/ingredients")
+	@ResponseStatus(HttpStatus.CREATED)
+	@ResponseBody
+	public IngredientGetDTO createIngredient(@RequestBody IngredientPostDTO dto) {
+		Ingredient ingredient = DTOMapper.INSTANCE.convertIngredientPostDTOtoEntity(dto);
+		Ingredient createdIngredient = ingredientService.createIngredient(ingredient);
+		return DTOMapper.INSTANCE.convertEntityToIngredientGetDTO(createdIngredient);
+	}
+}
+

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/PantryController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/PantryController.java
@@ -1,0 +1,70 @@
+package ch.uzh.ifi.hase.soprafs26.controller;
+
+import ch.uzh.ifi.hase.soprafs26.entity.*;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.*;
+import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
+import ch.uzh.ifi.hase.soprafs26.service.GroupService;
+import ch.uzh.ifi.hase.soprafs26.service.PantryService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class PantryController {
+
+	private final PantryService pantryService;
+	private final GroupService groupService;
+
+	@Autowired
+	public PantryController(PantryService pantryService, GroupService groupService) {
+		this.pantryService = pantryService;
+		this.groupService = groupService;
+	}
+
+	@GetMapping("/groups/my/pantry")
+	@ResponseStatus(HttpStatus.OK)
+	@ResponseBody
+	public PantryGetDTO getPantry(Authentication auth) {
+		Group group = groupService.getGroupOfUser(auth.getName());
+		Pantry pantry = pantryService.getPantryByGroupId(group.getId());
+		return DTOMapper.INSTANCE.convertEntityToPantryGetDTO(pantry);
+	}
+
+	@PostMapping("/groups/my/pantry/items")
+	@ResponseStatus(HttpStatus.CREATED)
+	@ResponseBody
+	public PantryItemGetDTO addItem(Authentication auth, @RequestBody PantryItemPostDTO dto) {
+		Group group = groupService.getGroupOfUser(auth.getName());
+		Pantry pantry = pantryService.getPantryByGroupId(group.getId());
+		PantryItem item = pantryService.addItemToPantry(
+				pantry.getId(), dto.getIngredientId(), dto.getQuantity());
+		return DTOMapper.INSTANCE.convertEntityToPantryItemGetDTO(item);
+	}
+
+	@GetMapping("/groups/my/pantry/items/{itemId}")
+	@ResponseStatus(HttpStatus.OK)
+	@ResponseBody
+	public PantryItemGetDTO getItem(Authentication auth, @PathVariable Long itemId) {
+		Group group = groupService.getGroupOfUser(auth.getName());
+		PantryItem item = pantryService.getItemByIdAndVerifyGroup(itemId, group.getId());
+		return DTOMapper.INSTANCE.convertEntityToPantryItemGetDTO(item);
+	}
+
+	@PutMapping("/groups/my/pantry/items/{itemId}")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void updateItem(Authentication auth, @PathVariable Long itemId,
+			@RequestBody PantryItemPutDTO dto) {
+		Group group = groupService.getGroupOfUser(auth.getName());
+		pantryService.getItemByIdAndVerifyGroup(itemId, group.getId());
+		pantryService.updateItem(itemId, dto.getIngredientId(), dto.getQuantity());
+	}
+
+	@DeleteMapping("/groups/my/pantry/items/{itemId}")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void deleteItem(Authentication auth, @PathVariable Long itemId) {
+		Group group = groupService.getGroupOfUser(auth.getName());
+		pantryService.getItemByIdAndVerifyGroup(itemId, group.getId());
+		pantryService.deleteItem(itemId);
+	}
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/ShoppingListController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/ShoppingListController.java
@@ -1,0 +1,81 @@
+package ch.uzh.ifi.hase.soprafs26.controller;
+
+import ch.uzh.ifi.hase.soprafs26.entity.*;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.*;
+import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
+import ch.uzh.ifi.hase.soprafs26.service.GroupService;
+import ch.uzh.ifi.hase.soprafs26.service.ShoppingListService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class ShoppingListController {
+
+	private final ShoppingListService shoppingListService;
+	private final GroupService groupService;
+
+	@Autowired
+	public ShoppingListController(ShoppingListService shoppingListService, GroupService groupService) {
+		this.shoppingListService = shoppingListService;
+		this.groupService = groupService;
+	}
+
+	@GetMapping("/groups/my/shopping-list")
+	@ResponseStatus(HttpStatus.OK)
+	@ResponseBody
+	public ShoppingListGetDTO getShoppingList(Authentication auth) {
+		Group group = groupService.getGroupOfUser(auth.getName());
+		ShoppingList list = shoppingListService.getShoppingListByGroupId(group.getId());
+		return DTOMapper.INSTANCE.convertEntityToShoppingListGetDTO(list);
+	}
+
+	@PostMapping("/groups/my/shopping-list/items")
+	@ResponseStatus(HttpStatus.CREATED)
+	@ResponseBody
+	public ShoppingListItemGetDTO addItem(Authentication auth, @RequestBody ShoppingListItemPostDTO dto) {
+		Group group = groupService.getGroupOfUser(auth.getName());
+		ShoppingList list = shoppingListService.getShoppingListByGroupId(group.getId());
+		ShoppingListItem item = shoppingListService.addItemToList(
+				list.getId(), dto.getIngredientId(), dto.getQuantity());
+		return DTOMapper.INSTANCE.convertEntityToShoppingListItemGetDTO(item);
+	}
+
+	@GetMapping("/groups/my/shopping-list/items/{itemId}")
+	@ResponseStatus(HttpStatus.OK)
+	@ResponseBody
+	public ShoppingListItemGetDTO getItem(Authentication auth, @PathVariable Long itemId) {
+		Group group = groupService.getGroupOfUser(auth.getName());
+		ShoppingListItem item = shoppingListService.getItemByIdAndVerifyGroup(itemId, group.getId());
+		return DTOMapper.INSTANCE.convertEntityToShoppingListItemGetDTO(item);
+	}
+
+	@PutMapping("/groups/my/shopping-list/items/{itemId}")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void updateItem(Authentication auth, @PathVariable Long itemId,
+			@RequestBody ItemPutDTO dto) {
+		Group group = groupService.getGroupOfUser(auth.getName());
+		shoppingListService.getItemByIdAndVerifyGroup(itemId, group.getId());
+		shoppingListService.updateItem(itemId, dto.getIngredientId(), dto.getQuantity());
+	}
+
+	@PatchMapping("/groups/my/shopping-list/items/{itemId}")
+	@ResponseStatus(HttpStatus.OK)
+	@ResponseBody
+	public ShoppingListItemGetDTO patchItemBoughtStatus(Authentication auth, @PathVariable Long itemId,
+			@RequestBody ItemPatchDTO dto) {
+		Group group = groupService.getGroupOfUser(auth.getName());
+		shoppingListService.getItemByIdAndVerifyGroup(itemId, group.getId());
+		ShoppingListItem item = shoppingListService.patchItemBoughtStatus(itemId, dto.getIsBought());
+		return DTOMapper.INSTANCE.convertEntityToShoppingListItemGetDTO(item);
+	}
+
+	@DeleteMapping("/groups/my/shopping-list/items/{itemId}")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void deleteItem(Authentication auth, @PathVariable Long itemId) {
+		Group group = groupService.getGroupOfUser(auth.getName());
+		shoppingListService.getItemByIdAndVerifyGroup(itemId, group.getId());
+		shoppingListService.deleteItem(itemId);
+	}
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Group.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Group.java
@@ -1,0 +1,48 @@
+package ch.uzh.ifi.hase.soprafs26.entity;
+
+import jakarta.persistence.*;
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "user_groups")
+public class Group implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	@Column(nullable = false)
+	private String name;
+
+	@Column(nullable = false, unique = true)
+	private String inviteCode;
+
+	@Column(nullable = false)
+	private Instant createdAt;
+
+	@OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<GroupMembership> memberships = new ArrayList<>();
+
+	@PrePersist
+	protected void onCreate() {
+		if (this.createdAt == null) {
+			this.createdAt = Instant.now();
+		}
+	}
+
+	public Long getId() { return id; }
+	public void setId(Long id) { this.id = id; }
+	public String getName() { return name; }
+	public void setName(String name) { this.name = name; }
+	public String getInviteCode() { return inviteCode; }
+	public void setInviteCode(String inviteCode) { this.inviteCode = inviteCode; }
+	public Instant getCreatedAt() { return createdAt; }
+	public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+	public List<GroupMembership> getMemberships() { return memberships; }
+	public void setMemberships(List<GroupMembership> memberships) { this.memberships = memberships; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/GroupMembership.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/GroupMembership.java
@@ -1,0 +1,53 @@
+package ch.uzh.ifi.hase.soprafs26.entity;
+
+import ch.uzh.ifi.hase.soprafs26.constant.GroupRole;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import java.io.Serializable;
+import java.time.Instant;
+
+@Entity
+@Table(name = "group_memberships",
+		uniqueConstraints = @UniqueConstraint(columnNames = "user_id"))
+public class GroupMembership implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "group_id", nullable = false)
+	@JsonIgnore
+	private Group group;
+
+	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
+	private GroupRole role;
+
+	@Column(nullable = false)
+	private Instant joinedAt;
+
+	@PrePersist
+	protected void onCreate() {
+		if (this.joinedAt == null) {
+			this.joinedAt = Instant.now();
+		}
+	}
+
+	public Long getId() { return id; }
+	public void setId(Long id) { this.id = id; }
+	public User getUser() { return user; }
+	public void setUser(User user) { this.user = user; }
+	public Group getGroup() { return group; }
+	public void setGroup(Group group) { this.group = group; }
+	public GroupRole getRole() { return role; }
+	public void setRole(GroupRole role) { this.role = role; }
+	public Instant getJoinedAt() { return joinedAt; }
+	public void setJoinedAt(Instant joinedAt) { this.joinedAt = joinedAt; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Ingredient.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Ingredient.java
@@ -1,0 +1,35 @@
+package ch.uzh.ifi.hase.soprafs26.entity;
+
+import jakarta.persistence.*;
+import ch.uzh.ifi.hase.soprafs26.constant.Unit;
+import java.io.Serializable;
+
+@Entity
+@Table(name = "ingredients")
+public class Ingredient implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	@Column(nullable = false, unique = true)
+	private String ingredientName;
+
+	@Column(nullable = true)
+	private String ingredientDescription;
+
+	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
+	private Unit unit;
+
+	public Long getId() { return id; }
+	public void setId(Long id) { this.id = id; }
+	public String getIngredientName() { return ingredientName; }
+	public void setIngredientName(String ingredientName) { this.ingredientName = ingredientName; }
+	public String getIngredientDescription() { return ingredientDescription; }
+	public void setIngredientDescription(String ingredientDescription) { this.ingredientDescription = ingredientDescription; }
+	public Unit getUnit() { return unit; }
+	public void setUnit(Unit unit) { this.unit = unit; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Pantry.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Pantry.java
@@ -1,0 +1,30 @@
+package ch.uzh.ifi.hase.soprafs26.entity;
+
+import jakarta.persistence.*;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "pantries")
+public class Pantry implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	@Column(nullable = false)
+	private Long groupId;
+
+	@OneToMany(mappedBy = "pantry", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<PantryItem> items = new ArrayList<>();
+
+	public Long getId() { return id; }
+	public void setId(Long id) { this.id = id; }
+	public Long getGroupId() { return groupId; }
+	public void setGroupId(Long groupId) { this.groupId = groupId; }
+	public List<PantryItem> getItems() { return items; }
+	public void setItems(List<PantryItem> items) { this.items = items; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/PantryItem.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/PantryItem.java
@@ -1,0 +1,37 @@
+package ch.uzh.ifi.hase.soprafs26.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import java.io.Serializable;
+
+@Entity
+@Table(name = "pantry_items")
+public class PantryItem implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	@Column(nullable = false)
+	private Integer quantity;
+
+	@ManyToOne
+	@JoinColumn(name = "ingredient_id", nullable = false)
+	private Ingredient ingredient;
+
+	@ManyToOne
+	@JoinColumn(name = "pantry_id", nullable = false)
+	@JsonIgnore
+	private Pantry pantry;
+
+	public Long getId() { return id; }
+	public void setId(Long id) { this.id = id; }
+	public Integer getQuantity() { return quantity; }
+	public void setQuantity(Integer quantity) { this.quantity = quantity; }
+	public Ingredient getIngredient() { return ingredient; }
+	public void setIngredient(Ingredient ingredient) { this.ingredient = ingredient; }
+	public Pantry getPantry() { return pantry; }
+	public void setPantry(Pantry pantry) { this.pantry = pantry; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/ShoppingList.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/ShoppingList.java
@@ -1,0 +1,30 @@
+package ch.uzh.ifi.hase.soprafs26.entity;
+
+import jakarta.persistence.*;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "shopping_lists")
+public class ShoppingList implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	@Column(nullable = false)
+	private Long groupId;
+
+	@OneToMany(mappedBy = "shoppingList", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<ShoppingListItem> items = new ArrayList<>();
+
+	public Long getId() { return id; }
+	public void setId(Long id) { this.id = id; }
+	public Long getGroupId() { return groupId; }
+	public void setGroupId(Long groupId) { this.groupId = groupId; }
+	public List<ShoppingListItem> getItems() { return items; }
+	public void setItems(List<ShoppingListItem> items) { this.items = items; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/ShoppingListItem.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/ShoppingListItem.java
@@ -1,0 +1,42 @@
+package ch.uzh.ifi.hase.soprafs26.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import java.io.Serializable;
+
+@Entity
+@Table(name = "shopping_list_items")
+public class ShoppingListItem implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	@Column(nullable = false)
+	private Integer quantity;
+
+	@Column(nullable = false)
+	private Boolean isBought = false;
+
+	@ManyToOne
+	@JoinColumn(name = "ingredient_id", nullable = false)
+	private Ingredient ingredient;
+
+	@ManyToOne
+	@JoinColumn(name = "shopping_list_id", nullable = false)
+	@JsonIgnore
+	private ShoppingList shoppingList;
+
+	public Long getId() { return id; }
+	public void setId(Long id) { this.id = id; }
+	public Integer getQuantity() { return quantity; }
+	public void setQuantity(Integer quantity) { this.quantity = quantity; }
+	public Boolean getIsBought() { return isBought; }
+	public void setIsBought(Boolean isBought) { this.isBought = isBought; }
+	public Ingredient getIngredient() { return ingredient; }
+	public void setIngredient(Ingredient ingredient) { this.ingredient = ingredient; }
+	public ShoppingList getShoppingList() { return shoppingList; }
+	public void setShoppingList(ShoppingList shoppingList) { this.shoppingList = shoppingList; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/GroupMembershipRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/GroupMembershipRepository.java
@@ -1,0 +1,15 @@
+package ch.uzh.ifi.hase.soprafs26.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import ch.uzh.ifi.hase.soprafs26.entity.GroupMembership;
+import java.util.List;
+import java.util.Optional;
+
+@Repository("groupMembershipRepository")
+public interface GroupMembershipRepository extends JpaRepository<GroupMembership, Long> {
+	Optional<GroupMembership> findByUserUserID(String userID);
+	Optional<GroupMembership> findByUserUserIDAndGroupId(String userID, Long groupId);
+	List<GroupMembership> findByGroupId(Long groupId);
+	long countByGroupId(Long groupId);
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/GroupRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/GroupRepository.java
@@ -1,0 +1,11 @@
+package ch.uzh.ifi.hase.soprafs26.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import ch.uzh.ifi.hase.soprafs26.entity.Group;
+import java.util.Optional;
+
+@Repository("groupRepository")
+public interface GroupRepository extends JpaRepository<Group, Long> {
+	Optional<Group> findByInviteCode(String inviteCode);
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/IngredientRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/IngredientRepository.java
@@ -4,6 +4,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import ch.uzh.ifi.hase.soprafs26.entity.Ingredient;
 
+import java.util.Optional;
+
 @Repository("ingredientRepository")
 public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
+	Optional<Ingredient> findByIngredientNameIgnoreCase(String ingredientName);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/IngredientRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/IngredientRepository.java
@@ -1,0 +1,9 @@
+package ch.uzh.ifi.hase.soprafs26.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import ch.uzh.ifi.hase.soprafs26.entity.Ingredient;
+
+@Repository("ingredientRepository")
+public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/PantryItemRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/PantryItemRepository.java
@@ -1,0 +1,9 @@
+package ch.uzh.ifi.hase.soprafs26.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import ch.uzh.ifi.hase.soprafs26.entity.PantryItem;
+
+@Repository("pantryItemRepository")
+public interface PantryItemRepository extends JpaRepository<PantryItem, Long> {
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/PantryRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/PantryRepository.java
@@ -1,0 +1,11 @@
+package ch.uzh.ifi.hase.soprafs26.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import ch.uzh.ifi.hase.soprafs26.entity.Pantry;
+import java.util.List;
+
+@Repository("pantryRepository")
+public interface PantryRepository extends JpaRepository<Pantry, Long> {
+	List<Pantry> findAllByGroupId(Long groupId);
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/ShoppingListItemRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/ShoppingListItemRepository.java
@@ -1,0 +1,9 @@
+package ch.uzh.ifi.hase.soprafs26.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import ch.uzh.ifi.hase.soprafs26.entity.ShoppingListItem;
+
+@Repository("shoppingListItemRepository")
+public interface ShoppingListItemRepository extends JpaRepository<ShoppingListItem, Long> {
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/ShoppingListRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/ShoppingListRepository.java
@@ -1,0 +1,11 @@
+package ch.uzh.ifi.hase.soprafs26.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import ch.uzh.ifi.hase.soprafs26.entity.ShoppingList;
+import java.util.List;
+
+@Repository("shoppingListRepository")
+public interface ShoppingListRepository extends JpaRepository<ShoppingList, Long> {
+	List<ShoppingList> findAllByGroupId(Long groupId);
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GroupGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GroupGetDTO.java
@@ -1,0 +1,23 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+public class GroupGetDTO {
+	private Long id;
+	private String name;
+	private String inviteCode;
+	private Instant createdAt;
+	private List<GroupMemberGetDTO> members;
+
+	public Long getId() { return id; }
+	public void setId(Long id) { this.id = id; }
+	public String getName() { return name; }
+	public void setName(String name) { this.name = name; }
+	public String getInviteCode() { return inviteCode; }
+	public void setInviteCode(String inviteCode) { this.inviteCode = inviteCode; }
+	public Instant getCreatedAt() { return createdAt; }
+	public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+	public List<GroupMemberGetDTO> getMembers() { return members; }
+	public void setMembers(List<GroupMemberGetDTO> members) { this.members = members; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GroupJoinPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GroupJoinPostDTO.java
@@ -1,0 +1,7 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+public class GroupJoinPostDTO {
+	private String inviteCode;
+	public String getInviteCode() { return inviteCode; }
+	public void setInviteCode(String inviteCode) { this.inviteCode = inviteCode; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GroupMemberGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GroupMemberGetDTO.java
@@ -1,0 +1,20 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+import ch.uzh.ifi.hase.soprafs26.constant.GroupRole;
+import java.time.Instant;
+
+public class GroupMemberGetDTO {
+	private String userID;
+	private String username;
+	private GroupRole role;
+	private Instant joinedAt;
+
+	public String getUserID() { return userID; }
+	public void setUserID(String userID) { this.userID = userID; }
+	public String getUsername() { return username; }
+	public void setUsername(String username) { this.username = username; }
+	public GroupRole getRole() { return role; }
+	public void setRole(GroupRole role) { this.role = role; }
+	public Instant getJoinedAt() { return joinedAt; }
+	public void setJoinedAt(Instant joinedAt) { this.joinedAt = joinedAt; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GroupPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GroupPostDTO.java
@@ -1,0 +1,7 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+public class GroupPostDTO {
+	private String name;
+	public String getName() { return name; }
+	public void setName(String name) { this.name = name; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GroupRolePutDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GroupRolePutDTO.java
@@ -1,0 +1,9 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+import ch.uzh.ifi.hase.soprafs26.constant.GroupRole;
+
+public class GroupRolePutDTO {
+	private GroupRole role;
+	public GroupRole getRole() { return role; }
+	public void setRole(GroupRole role) { this.role = role; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/IngredientGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/IngredientGetDTO.java
@@ -1,0 +1,43 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+import ch.uzh.ifi.hase.soprafs26.constant.Unit;
+
+public class IngredientGetDTO {
+	private Long id;
+	private String ingredientName;
+	private String ingredientDescription;
+	private Unit unit;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getIngredientName() {
+		return ingredientName;
+	}
+
+	public void setIngredientName(String ingredientName) {
+		this.ingredientName = ingredientName;
+	}
+
+	public String getIngredientDescription() {
+		return ingredientDescription;
+	}
+
+	public void setIngredientDescription(String ingredientDescription) {
+		this.ingredientDescription = ingredientDescription;
+	}
+
+	public Unit getUnit() {
+		return unit;
+	}
+
+	public void setUnit(Unit unit) {
+		this.unit = unit;
+	}
+}
+

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/IngredientPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/IngredientPostDTO.java
@@ -1,0 +1,34 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+import ch.uzh.ifi.hase.soprafs26.constant.Unit;
+
+public class IngredientPostDTO {
+	private String ingredientName;
+	private String ingredientDescription;
+	private Unit unit;
+
+	public String getIngredientName() {
+		return ingredientName;
+	}
+
+	public void setIngredientName(String ingredientName) {
+		this.ingredientName = ingredientName;
+	}
+
+	public String getIngredientDescription() {
+		return ingredientDescription;
+	}
+
+	public void setIngredientDescription(String ingredientDescription) {
+		this.ingredientDescription = ingredientDescription;
+	}
+
+	public Unit getUnit() {
+		return unit;
+	}
+
+	public void setUnit(Unit unit) {
+		this.unit = unit;
+	}
+}
+

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/ItemPatchDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/ItemPatchDTO.java
@@ -1,0 +1,8 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+public class ItemPatchDTO {
+	private Boolean isBought;
+
+	public Boolean getIsBought() { return isBought; }
+	public void setIsBought(Boolean isBought) { this.isBought = isBought; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/ItemPutDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/ItemPutDTO.java
@@ -1,0 +1,11 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+public class ItemPutDTO {
+	private Long ingredientId;
+	private Integer quantity;
+
+	public Long getIngredientId() { return ingredientId; }
+	public void setIngredientId(Long ingredientId) { this.ingredientId = ingredientId; }
+	public Integer getQuantity() { return quantity; }
+	public void setQuantity(Integer quantity) { this.quantity = quantity; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/PantryGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/PantryGetDTO.java
@@ -1,0 +1,16 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+import java.util.List;
+
+public class PantryGetDTO {
+	private Long id;
+	private Long groupId;
+	private List<PantryItemGetDTO> items;
+
+	public Long getId() { return id; }
+	public void setId(Long id) { this.id = id; }
+	public Long getGroupId() { return groupId; }
+	public void setGroupId(Long groupId) { this.groupId = groupId; }
+	public List<PantryItemGetDTO> getItems() { return items; }
+	public void setItems(List<PantryItemGetDTO> items) { this.items = items; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/PantryItemGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/PantryItemGetDTO.java
@@ -1,0 +1,22 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+import ch.uzh.ifi.hase.soprafs26.constant.Unit;
+
+public class PantryItemGetDTO {
+	private Long id;
+	private Integer quantity;
+	private Long ingredientId;
+	private String ingredientName;
+	private Unit unit;
+
+	public Long getId() { return id; }
+	public void setId(Long id) { this.id = id; }
+	public Integer getQuantity() { return quantity; }
+	public void setQuantity(Integer quantity) { this.quantity = quantity; }
+	public Long getIngredientId() { return ingredientId; }
+	public void setIngredientId(Long ingredientId) { this.ingredientId = ingredientId; }
+	public String getIngredientName() { return ingredientName; }
+	public void setIngredientName(String ingredientName) { this.ingredientName = ingredientName; }
+	public Unit getUnit() { return unit; }
+	public void setUnit(Unit unit) { this.unit = unit; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/PantryItemPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/PantryItemPostDTO.java
@@ -1,0 +1,11 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+public class PantryItemPostDTO {
+	private Long ingredientId;
+	private Integer quantity;
+
+	public Long getIngredientId() { return ingredientId; }
+	public void setIngredientId(Long ingredientId) { this.ingredientId = ingredientId; }
+	public Integer getQuantity() { return quantity; }
+	public void setQuantity(Integer quantity) { this.quantity = quantity; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/PantryItemPutDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/PantryItemPutDTO.java
@@ -1,0 +1,11 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+public class PantryItemPutDTO {
+	private Long ingredientId;
+	private Integer quantity;
+
+	public Long getIngredientId() { return ingredientId; }
+	public void setIngredientId(Long ingredientId) { this.ingredientId = ingredientId; }
+	public Integer getQuantity() { return quantity; }
+	public void setQuantity(Integer quantity) { this.quantity = quantity; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/ShoppingListGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/ShoppingListGetDTO.java
@@ -1,0 +1,16 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+import java.util.List;
+
+public class ShoppingListGetDTO {
+	private Long id;
+	private Long groupId;
+	private List<ShoppingListItemGetDTO> items;
+
+	public Long getId() { return id; }
+	public void setId(Long id) { this.id = id; }
+	public Long getGroupId() { return groupId; }
+	public void setGroupId(Long groupId) { this.groupId = groupId; }
+	public List<ShoppingListItemGetDTO> getItems() { return items; }
+	public void setItems(List<ShoppingListItemGetDTO> items) { this.items = items; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/ShoppingListItemGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/ShoppingListItemGetDTO.java
@@ -1,0 +1,25 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+import ch.uzh.ifi.hase.soprafs26.constant.Unit;
+
+public class ShoppingListItemGetDTO {
+	private Long id;
+	private Integer quantity;
+	private Boolean isBought;
+	private Long ingredientId;
+	private String ingredientName;
+	private Unit unit;
+
+	public Long getId() { return id; }
+	public void setId(Long id) { this.id = id; }
+	public Integer getQuantity() { return quantity; }
+	public void setQuantity(Integer quantity) { this.quantity = quantity; }
+	public Boolean getIsBought() { return isBought; }
+	public void setIsBought(Boolean isBought) { this.isBought = isBought; }
+	public Long getIngredientId() { return ingredientId; }
+	public void setIngredientId(Long ingredientId) { this.ingredientId = ingredientId; }
+	public String getIngredientName() { return ingredientName; }
+	public void setIngredientName(String ingredientName) { this.ingredientName = ingredientName; }
+	public Unit getUnit() { return unit; }
+	public void setUnit(Unit unit) { this.unit = unit; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/ShoppingListItemPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/ShoppingListItemPostDTO.java
@@ -1,0 +1,11 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+public class ShoppingListItemPostDTO {
+	private Long ingredientId;
+	private Integer quantity;
+
+	public Long getIngredientId() { return ingredientId; }
+	public void setIngredientId(Long ingredientId) { this.ingredientId = ingredientId; }
+	public Integer getQuantity() { return quantity; }
+	public void setQuantity(Integer quantity) { this.quantity = quantity; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -3,9 +3,7 @@ package ch.uzh.ifi.hase.soprafs26.rest.mapper;
 import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
 
-import ch.uzh.ifi.hase.soprafs26.entity.Group;
-import ch.uzh.ifi.hase.soprafs26.entity.GroupMembership;
-import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.entity.*;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.*;
 
 @Mapper
@@ -57,4 +55,19 @@ public interface DTOMapper {
 	@Mapping(source = "role", target = "role")
 	@Mapping(source = "joinedAt", target = "joinedAt")
 	GroupMemberGetDTO convertEntityToGroupMemberGetDTO(GroupMembership membership);
+
+	// ─── Shopping list mappings ─────────────────────
+
+	@Mapping(source = "id", target = "id")
+	@Mapping(source = "groupId", target = "groupId")
+	@Mapping(source = "items", target = "items")
+	ShoppingListGetDTO convertEntityToShoppingListGetDTO(ShoppingList shoppingList);
+
+	@Mapping(source = "id", target = "id")
+	@Mapping(source = "quantity", target = "quantity")
+	@Mapping(source = "isBought", target = "isBought")
+	@Mapping(source = "ingredient.id", target = "ingredientId")
+	@Mapping(source = "ingredient.ingredientName", target = "ingredientName")
+	@Mapping(source = "ingredient.unit", target = "unit")
+	ShoppingListItemGetDTO convertEntityToShoppingListItemGetDTO(ShoppingListItem item);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -3,17 +3,17 @@ package ch.uzh.ifi.hase.soprafs26.rest.mapper;
 import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
 
+import ch.uzh.ifi.hase.soprafs26.entity.Group;
+import ch.uzh.ifi.hase.soprafs26.entity.GroupMembership;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.LoginGetDTO;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.LoginPostDTO;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.RegisterPostDTO;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.UserGetDTO;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.UserPostDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.*;
 
 @Mapper
 public interface DTOMapper {
 
 	DTOMapper INSTANCE = Mappers.getMapper(DTOMapper.class);
+
+	// ─── User mappings (from main) ──────────────────
 
 	@BeanMapping(ignoreByDefault = true)
 	@Mapping(source = "email", target = "email")
@@ -43,7 +43,18 @@ public interface DTOMapper {
 	@Mapping(source = "status", target = "status")
 	UserGetDTO convertEntityToUserGetDTO(User user);
 
-    @Mapping(source = "userID", target = "userID")
-    @Mapping(source = "token", target = "token")
-    LoginGetDTO convertEntityToLoginGetDTO(User user);
+	@Mapping(source = "userID", target = "userID")
+	@Mapping(source = "token", target = "token")
+	LoginGetDTO convertEntityToLoginGetDTO(User user);
+
+	// ─── Group mappings ─────────────────────────────
+
+	@Mapping(source = "memberships", target = "members")
+	GroupGetDTO convertEntityToGroupGetDTO(Group group);
+
+	@Mapping(source = "user.userID", target = "userID")
+	@Mapping(source = "user.username", target = "username")
+	@Mapping(source = "role", target = "role")
+	@Mapping(source = "joinedAt", target = "joinedAt")
+	GroupMemberGetDTO convertEntityToGroupMemberGetDTO(GroupMembership membership);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -84,4 +84,18 @@ public interface DTOMapper {
 	@Mapping(source = "ingredient.ingredientName", target = "ingredientName")
 	@Mapping(source = "ingredient.unit", target = "unit")
 	PantryItemGetDTO convertEntityToPantryItemGetDTO(PantryItem pantryItem);
+
+	// ─── Ingredient mappings ────────────────────────
+
+	@BeanMapping(ignoreByDefault = true)
+	@Mapping(source = "ingredientName", target = "ingredientName")
+	@Mapping(source = "ingredientDescription", target = "ingredientDescription")
+	@Mapping(source = "unit", target = "unit")
+	Ingredient convertIngredientPostDTOtoEntity(IngredientPostDTO ingredientPostDTO);
+
+	@Mapping(source = "id", target = "id")
+	@Mapping(source = "ingredientName", target = "ingredientName")
+	@Mapping(source = "ingredientDescription", target = "ingredientDescription")
+	@Mapping(source = "unit", target = "unit")
+	IngredientGetDTO convertEntityToIngredientGetDTO(Ingredient ingredient);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -70,4 +70,18 @@ public interface DTOMapper {
 	@Mapping(source = "ingredient.ingredientName", target = "ingredientName")
 	@Mapping(source = "ingredient.unit", target = "unit")
 	ShoppingListItemGetDTO convertEntityToShoppingListItemGetDTO(ShoppingListItem item);
+
+	// ─── Pantry mappings ────────────────────────────
+
+	@Mapping(source = "id", target = "id")
+	@Mapping(source = "groupId", target = "groupId")
+	@Mapping(source = "items", target = "items")
+	PantryGetDTO convertEntityToPantryGetDTO(Pantry pantry);
+
+	@Mapping(source = "id", target = "id")
+	@Mapping(source = "quantity", target = "quantity")
+	@Mapping(source = "ingredient.id", target = "ingredientId")
+	@Mapping(source = "ingredient.ingredientName", target = "ingredientName")
+	@Mapping(source = "ingredient.unit", target = "unit")
+	PantryItemGetDTO convertEntityToPantryItemGetDTO(PantryItem pantryItem);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GroupService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GroupService.java
@@ -1,0 +1,223 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import ch.uzh.ifi.hase.soprafs26.constant.GroupRole;
+import ch.uzh.ifi.hase.soprafs26.entity.Group;
+import ch.uzh.ifi.hase.soprafs26.entity.GroupMembership;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.repository.GroupMembershipRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.GroupRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.security.SecureRandom;
+import java.util.List;
+
+@Service
+@Transactional
+public class GroupService {
+
+	private final Logger log = LoggerFactory.getLogger(GroupService.class);
+
+	private static final int MAX_MEMBERS = 100;
+	private static final int INVITE_CODE_LENGTH = 8;
+	private static final String INVITE_CODE_CHARS = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+	private static final SecureRandom RANDOM = new SecureRandom();
+
+	private final GroupRepository groupRepository;
+	private final GroupMembershipRepository membershipRepository;
+
+	@Autowired
+	public GroupService(GroupRepository groupRepository,
+			GroupMembershipRepository membershipRepository) {
+		this.groupRepository = groupRepository;
+		this.membershipRepository = membershipRepository;
+	}
+
+	public Group createGroup(User creator, String groupName) {
+		ensureUserNotInGroup(creator.getUserID());
+
+		Group group = new Group();
+		group.setName(groupName);
+		group.setInviteCode(generateUniqueInviteCode());
+		group = groupRepository.save(group);
+		groupRepository.flush();
+
+		GroupMembership membership = new GroupMembership();
+		membership.setUser(creator);
+		membership.setGroup(group);
+		membership.setRole(GroupRole.ADMIN);
+		membershipRepository.save(membership);
+		membershipRepository.flush();
+
+		log.debug("Created group '{}' (id={}) with admin userID={}", groupName, group.getId(), creator.getUserID());
+		return group;
+	}
+
+	public Group joinGroup(User joiner, String inviteCode) {
+		ensureUserNotInGroup(joiner.getUserID());
+
+		Group group = groupRepository.findByInviteCode(inviteCode)
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+						"No group found with that invite code"));
+
+		long memberCount = membershipRepository.countByGroupId(group.getId());
+		if (memberCount >= MAX_MEMBERS) {
+			throw new ResponseStatusException(HttpStatus.CONFLICT,
+					"Group has reached the maximum of " + MAX_MEMBERS + " members");
+		}
+
+		GroupMembership membership = new GroupMembership();
+		membership.setUser(joiner);
+		membership.setGroup(group);
+		membership.setRole(GroupRole.MEMBER);
+		membershipRepository.save(membership);
+		membershipRepository.flush();
+
+		log.debug("User {} joined group {} via invite code", joiner.getUserID(), group.getId());
+		return group;
+	}
+
+	public Group getGroupOfUser(String userID) {
+		GroupMembership membership = membershipRepository.findByUserUserID(userID)
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+						"You are not a member of any group"));
+		return membership.getGroup();
+	}
+
+	public Group updateGroupName(User admin, String newName) {
+		GroupMembership membership = getAdminMembership(admin.getUserID());
+		Group group = membership.getGroup();
+		group.setName(newName);
+		groupRepository.save(group);
+		groupRepository.flush();
+		return group;
+	}
+
+	public Group regenerateInviteCode(User admin) {
+		GroupMembership membership = getAdminMembership(admin.getUserID());
+		Group group = membership.getGroup();
+		group.setInviteCode(generateUniqueInviteCode());
+		groupRepository.save(group);
+		groupRepository.flush();
+		return group;
+	}
+
+	public void updateMemberRole(User admin, String targetUserID, GroupRole newRole) {
+		GroupMembership adminMembership = getAdminMembership(admin.getUserID());
+		Long groupId = adminMembership.getGroup().getId();
+
+		GroupMembership targetMembership = membershipRepository.findByUserUserIDAndGroupId(targetUserID, groupId)
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+						"Target user is not a member of your group"));
+
+		if (targetMembership.getRole() == GroupRole.ADMIN && newRole == GroupRole.MEMBER) {
+			if (countAdmins(groupId) <= 1) {
+				throw new ResponseStatusException(HttpStatus.CONFLICT,
+						"Cannot demote the only admin. Promote another member first.");
+			}
+		}
+
+		targetMembership.setRole(newRole);
+		membershipRepository.save(targetMembership);
+		membershipRepository.flush();
+	}
+
+	public void removeMember(User admin, String targetUserID) {
+		GroupMembership adminMembership = getAdminMembership(admin.getUserID());
+		Long groupId = adminMembership.getGroup().getId();
+
+		GroupMembership targetMembership = membershipRepository.findByUserUserIDAndGroupId(targetUserID, groupId)
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+						"Target user is not a member of your group"));
+
+		if (targetMembership.getRole() == GroupRole.ADMIN) {
+			if (countAdmins(groupId) <= 1) {
+				throw new ResponseStatusException(HttpStatus.CONFLICT,
+						"Cannot remove the only admin. Delete the group instead, or promote another member first.");
+			}
+		}
+
+		membershipRepository.delete(targetMembership);
+		membershipRepository.flush();
+	}
+
+	public void leaveGroup(User user) {
+		GroupMembership membership = membershipRepository.findByUserUserID(user.getUserID())
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+						"You are not a member of any group"));
+
+		if (membership.getRole() == GroupRole.ADMIN) {
+			long adminCount = countAdmins(membership.getGroup().getId());
+			if (adminCount <= 1) {
+				long totalMembers = membershipRepository.countByGroupId(membership.getGroup().getId());
+				if (totalMembers > 1) {
+					throw new ResponseStatusException(HttpStatus.CONFLICT,
+							"You are the only admin. Promote another member to admin before leaving, or delete the group.");
+				}
+				deleteGroupInternal(membership.getGroup());
+				return;
+			}
+		}
+
+		membershipRepository.delete(membership);
+		membershipRepository.flush();
+	}
+
+	public void deleteGroup(User admin) {
+		GroupMembership membership = getAdminMembership(admin.getUserID());
+		deleteGroupInternal(membership.getGroup());
+	}
+
+	// ─── helpers ───────────────────────────────────────────────
+
+	private void deleteGroupInternal(Group group) {
+		groupRepository.delete(group);
+		groupRepository.flush();
+		log.debug("Deleted group {}", group.getId());
+	}
+
+	private void ensureUserNotInGroup(String userID) {
+		if (membershipRepository.findByUserUserID(userID).isPresent()) {
+			throw new ResponseStatusException(HttpStatus.CONFLICT,
+					"You are already a member of a group. Leave your current group first.");
+		}
+	}
+
+	private GroupMembership getAdminMembership(String userID) {
+		GroupMembership membership = membershipRepository.findByUserUserID(userID)
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+						"You are not a member of any group"));
+		if (membership.getRole() != GroupRole.ADMIN) {
+			throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+					"Only group admins can perform this action");
+		}
+		return membership;
+	}
+
+	private long countAdmins(Long groupId) {
+		return membershipRepository.findByGroupId(groupId).stream()
+				.filter(m -> m.getRole() == GroupRole.ADMIN)
+				.count();
+	}
+
+	private String generateUniqueInviteCode() {
+		String code;
+		do {
+			code = generateRandomCode();
+		} while (groupRepository.findByInviteCode(code).isPresent());
+		return code;
+	}
+
+	private String generateRandomCode() {
+		StringBuilder sb = new StringBuilder(INVITE_CODE_LENGTH);
+		for (int i = 0; i < INVITE_CODE_LENGTH; i++) {
+			sb.append(INVITE_CODE_CHARS.charAt(RANDOM.nextInt(INVITE_CODE_CHARS.length())));
+		}
+		return sb.toString();
+	}
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GroupService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GroupService.java
@@ -1,11 +1,8 @@
 package ch.uzh.ifi.hase.soprafs26.service;
 
 import ch.uzh.ifi.hase.soprafs26.constant.GroupRole;
-import ch.uzh.ifi.hase.soprafs26.entity.Group;
-import ch.uzh.ifi.hase.soprafs26.entity.GroupMembership;
-import ch.uzh.ifi.hase.soprafs26.entity.User;
-import ch.uzh.ifi.hase.soprafs26.repository.GroupMembershipRepository;
-import ch.uzh.ifi.hase.soprafs26.repository.GroupRepository;
+import ch.uzh.ifi.hase.soprafs26.entity.*;
+import ch.uzh.ifi.hase.soprafs26.repository.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,12 +27,15 @@ public class GroupService {
 
 	private final GroupRepository groupRepository;
 	private final GroupMembershipRepository membershipRepository;
+	private final ShoppingListRepository shoppingListRepository;
 
 	@Autowired
 	public GroupService(GroupRepository groupRepository,
-			GroupMembershipRepository membershipRepository) {
+			GroupMembershipRepository membershipRepository,
+			ShoppingListRepository shoppingListRepository) {
 		this.groupRepository = groupRepository;
 		this.membershipRepository = membershipRepository;
+		this.shoppingListRepository = shoppingListRepository;
 	}
 
 	public Group createGroup(User creator, String groupName) {
@@ -53,6 +53,11 @@ public class GroupService {
 		membership.setRole(GroupRole.ADMIN);
 		membershipRepository.save(membership);
 		membershipRepository.flush();
+
+		ShoppingList shoppingList = new ShoppingList();
+		shoppingList.setGroupId(group.getId());
+		shoppingListRepository.save(shoppingList);
+		shoppingListRepository.flush();
 
 		log.debug("Created group '{}' (id={}) with admin userID={}", groupName, group.getId(), creator.getUserID());
 		return group;
@@ -176,10 +181,12 @@ public class GroupService {
 	// ─── helpers ───────────────────────────────────────────────
 
 	private void deleteGroupInternal(Group group) {
+		shoppingListRepository.deleteAll(shoppingListRepository.findAllByGroupId(group.getId()));
 		groupRepository.delete(group);
 		groupRepository.flush();
 		log.debug("Deleted group {}", group.getId());
 	}
+
 
 	private void ensureUserNotInGroup(String userID) {
 		if (membershipRepository.findByUserUserID(userID).isPresent()) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GroupService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GroupService.java
@@ -28,14 +28,17 @@ public class GroupService {
 	private final GroupRepository groupRepository;
 	private final GroupMembershipRepository membershipRepository;
 	private final ShoppingListRepository shoppingListRepository;
+	private final PantryRepository pantryRepository;
 
 	@Autowired
 	public GroupService(GroupRepository groupRepository,
 			GroupMembershipRepository membershipRepository,
-			ShoppingListRepository shoppingListRepository) {
+			ShoppingListRepository shoppingListRepository,
+			PantryRepository pantryRepository) {
 		this.groupRepository = groupRepository;
 		this.membershipRepository = membershipRepository;
 		this.shoppingListRepository = shoppingListRepository;
+		this.pantryRepository = pantryRepository;
 	}
 
 	public Group createGroup(User creator, String groupName) {
@@ -58,6 +61,11 @@ public class GroupService {
 		shoppingList.setGroupId(group.getId());
 		shoppingListRepository.save(shoppingList);
 		shoppingListRepository.flush();
+
+		Pantry pantry = new Pantry();
+		pantry.setGroupId(group.getId());
+		pantryRepository.save(pantry);
+		pantryRepository.flush();
 
 		log.debug("Created group '{}' (id={}) with admin userID={}", groupName, group.getId(), creator.getUserID());
 		return group;
@@ -182,6 +190,7 @@ public class GroupService {
 
 	private void deleteGroupInternal(Group group) {
 		shoppingListRepository.deleteAll(shoppingListRepository.findAllByGroupId(group.getId()));
+		pantryRepository.deleteAll(pantryRepository.findAllByGroupId(group.getId()));
 		groupRepository.delete(group);
 		groupRepository.flush();
 		log.debug("Deleted group {}", group.getId());

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/IngredientService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/IngredientService.java
@@ -1,0 +1,49 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import ch.uzh.ifi.hase.soprafs26.entity.Ingredient;
+import ch.uzh.ifi.hase.soprafs26.repository.IngredientRepository;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class IngredientService {
+
+	private final IngredientRepository ingredientRepository;
+
+	public IngredientService(@Qualifier("ingredientRepository") IngredientRepository ingredientRepository) {
+		this.ingredientRepository = ingredientRepository;
+	}
+
+	public List<Ingredient> getIngredients() {
+		return ingredientRepository.findAll();
+	}
+
+	public Ingredient createIngredient(Ingredient ingredient) {
+		if (ingredient == null) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Ingredient payload must be provided");
+		}
+		if (ingredient.getIngredientName() == null || ingredient.getIngredientName().trim().isEmpty()) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Ingredient name must be provided");
+		}
+		if (ingredient.getUnit() == null) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Ingredient unit must be provided");
+		}
+
+		String normalizedName = ingredient.getIngredientName().trim();
+		ingredient.setIngredientName(normalizedName);
+
+		ingredientRepository.findByIngredientNameIgnoreCase(normalizedName).ifPresent(existing -> {
+			throw new ResponseStatusException(HttpStatus.CONFLICT,
+					String.format("Ingredient '%s' already exists", normalizedName));
+		});
+
+		return ingredientRepository.saveAndFlush(ingredient);
+	}
+}
+

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/PantryService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/PantryService.java
@@ -1,0 +1,97 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import ch.uzh.ifi.hase.soprafs26.entity.*;
+import ch.uzh.ifi.hase.soprafs26.repository.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@Transactional
+public class PantryService {
+
+	private final Logger log = LoggerFactory.getLogger(PantryService.class);
+
+	private final PantryRepository pantryRepository;
+	private final PantryItemRepository pantryItemRepository;
+	private final IngredientRepository ingredientRepository;
+
+	@Autowired
+	public PantryService(@Qualifier("pantryRepository") PantryRepository pantryRepository,
+			@Qualifier("pantryItemRepository") PantryItemRepository pantryItemRepository,
+			@Qualifier("ingredientRepository") IngredientRepository ingredientRepository) {
+		this.pantryRepository = pantryRepository;
+		this.pantryItemRepository = pantryItemRepository;
+		this.ingredientRepository = ingredientRepository;
+	}
+
+	public Pantry getPantryByGroupId(Long groupId) {
+		return pantryRepository.findAllByGroupId(groupId).stream()
+				.findFirst()
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+						"No pantry found for this group"));
+	}
+
+	public PantryItem addItemToPantry(Long pantryId, Long ingredientId, Integer quantity) {
+		Pantry pantry = pantryRepository.findById(pantryId)
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Pantry not found"));
+		Ingredient ingredient = ingredientRepository.findById(ingredientId)
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Ingredient not found"));
+
+		for (PantryItem existing : pantry.getItems()) {
+			if (existing.getIngredient().getId().equals(ingredientId)) {
+				existing.setQuantity(existing.getQuantity() + quantity);
+				pantryItemRepository.save(existing);
+				pantryItemRepository.flush();
+				log.debug("Merged quantity for ingredient {} in pantry {}", ingredientId, pantryId);
+				return existing;
+			}
+		}
+
+		PantryItem newItem = new PantryItem();
+		newItem.setPantry(pantry);
+		newItem.setIngredient(ingredient);
+		newItem.setQuantity(quantity);
+		pantry.getItems().add(newItem);
+		newItem = pantryItemRepository.save(newItem);
+		pantryItemRepository.flush();
+		log.debug("Added ingredient {} to pantry {}", ingredientId, pantryId);
+		return newItem;
+	}
+
+	public PantryItem getItemById(Long itemId) {
+		return pantryItemRepository.findById(itemId)
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Pantry item not found"));
+	}
+
+	public PantryItem getItemByIdAndVerifyGroup(Long itemId, Long groupId) {
+		PantryItem item = getItemById(itemId);
+		if (!item.getPantry().getGroupId().equals(groupId)) {
+			throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+					"This item does not belong to your group's pantry");
+		}
+		return item;
+	}
+
+	public void updateItem(Long itemId, Long ingredientId, Integer quantity) {
+		PantryItem item = getItemById(itemId);
+		Ingredient ingredient = ingredientRepository.findById(ingredientId)
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Ingredient not found"));
+		item.setIngredient(ingredient);
+		item.setQuantity(quantity);
+		pantryItemRepository.save(item);
+		pantryItemRepository.flush();
+	}
+
+	public void deleteItem(Long itemId) {
+		PantryItem item = getItemById(itemId);
+		item.getPantry().getItems().remove(item);
+		pantryItemRepository.delete(item);
+		pantryItemRepository.flush();
+	}
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/ShoppingListService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/ShoppingListService.java
@@ -52,6 +52,16 @@ public class ShoppingListService {
 		Ingredient ingredient = ingredientRepository.findById(ingredientId)
 				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Ingredient not found"));
 
+		for (ShoppingListItem existing : list.getItems()) {
+			if (existing.getIngredient().getId().equals(ingredientId) && Boolean.FALSE.equals(existing.getIsBought())) {
+				existing.setQuantity(existing.getQuantity() + quantity);
+				shoppingListItemRepository.save(existing);
+				shoppingListItemRepository.flush();
+				log.debug("Merged quantity for ingredient {} in shopping list {}", ingredientId, listId);
+				return existing;
+			}
+		}
+
 		ShoppingListItem item = new ShoppingListItem();
 		item.setShoppingList(list);
 		item.setIngredient(ingredient);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/ShoppingListService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/ShoppingListService.java
@@ -1,0 +1,102 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import ch.uzh.ifi.hase.soprafs26.entity.*;
+import ch.uzh.ifi.hase.soprafs26.repository.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class ShoppingListService {
+
+	private final Logger log = LoggerFactory.getLogger(ShoppingListService.class);
+
+	private final ShoppingListRepository shoppingListRepository;
+	private final ShoppingListItemRepository shoppingListItemRepository;
+	private final IngredientRepository ingredientRepository;
+
+	@Autowired
+	public ShoppingListService(@Qualifier("shoppingListRepository") ShoppingListRepository shoppingListRepository,
+			@Qualifier("shoppingListItemRepository") ShoppingListItemRepository shoppingListItemRepository,
+			@Qualifier("ingredientRepository") IngredientRepository ingredientRepository) {
+		this.shoppingListRepository = shoppingListRepository;
+		this.shoppingListItemRepository = shoppingListItemRepository;
+		this.ingredientRepository = ingredientRepository;
+	}
+
+	public ShoppingList getShoppingListByGroupId(Long groupId) {
+		List<ShoppingList> lists = shoppingListRepository.findAllByGroupId(groupId);
+		if (lists.isEmpty()) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No shopping list found for this group");
+		}
+		return lists.get(0);
+	}
+
+	public ShoppingListItem addItemToList(Long listId, Long ingredientId, Integer quantity) {
+		ShoppingList list = shoppingListRepository.findById(listId)
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Shopping list not found"));
+		Ingredient ingredient = ingredientRepository.findById(ingredientId)
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Ingredient not found"));
+
+		ShoppingListItem item = new ShoppingListItem();
+		item.setShoppingList(list);
+		item.setIngredient(ingredient);
+		item.setQuantity(quantity);
+		item.setIsBought(false);
+		list.getItems().add(item);
+
+		item = shoppingListItemRepository.save(item);
+		shoppingListItemRepository.flush();
+		log.debug("Added ingredient {} to shopping list {}", ingredientId, listId);
+		return item;
+	}
+
+	public ShoppingListItem getItemById(Long itemId) {
+		return shoppingListItemRepository.findById(itemId)
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Shopping list item not found"));
+	}
+
+	public ShoppingListItem getItemByIdAndVerifyGroup(Long itemId, Long groupId) {
+		ShoppingListItem item = getItemById(itemId);
+		if (!item.getShoppingList().getGroupId().equals(groupId)) {
+			throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+					"This item does not belong to your group's shopping list");
+		}
+		return item;
+	}
+
+	public void updateItem(Long itemId, Long ingredientId, Integer quantity) {
+		ShoppingListItem item = getItemById(itemId);
+		Ingredient ingredient = ingredientRepository.findById(ingredientId)
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Ingredient not found"));
+		item.setIngredient(ingredient);
+		item.setQuantity(quantity);
+		shoppingListItemRepository.save(item);
+		shoppingListItemRepository.flush();
+	}
+
+	public void deleteItem(Long itemId) {
+		ShoppingListItem item = getItemById(itemId);
+		ShoppingList list = item.getShoppingList();
+		list.getItems().remove(item);
+		shoppingListItemRepository.delete(item);
+		shoppingListItemRepository.flush();
+	}
+
+	public ShoppingListItem patchItemBoughtStatus(Long itemId, Boolean isBought) {
+		ShoppingListItem item = getItemById(itemId);
+		item.setIsBought(isBought);
+		item = shoppingListItemRepository.save(item);
+		shoppingListItemRepository.flush();
+
+		return item;
+	}
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/ShoppingListService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/ShoppingListService.java
@@ -22,14 +22,20 @@ public class ShoppingListService {
 	private final ShoppingListRepository shoppingListRepository;
 	private final ShoppingListItemRepository shoppingListItemRepository;
 	private final IngredientRepository ingredientRepository;
+	private final PantryRepository pantryRepository;
+	private final PantryService pantryService;
 
 	@Autowired
 	public ShoppingListService(@Qualifier("shoppingListRepository") ShoppingListRepository shoppingListRepository,
 			@Qualifier("shoppingListItemRepository") ShoppingListItemRepository shoppingListItemRepository,
-			@Qualifier("ingredientRepository") IngredientRepository ingredientRepository) {
+			@Qualifier("ingredientRepository") IngredientRepository ingredientRepository,
+			@Qualifier("pantryRepository") PantryRepository pantryRepository,
+			PantryService pantryService) {
 		this.shoppingListRepository = shoppingListRepository;
 		this.shoppingListItemRepository = shoppingListItemRepository;
 		this.ingredientRepository = ingredientRepository;
+		this.pantryRepository = pantryRepository;
+		this.pantryService = pantryService;
 	}
 
 	public ShoppingList getShoppingListByGroupId(Long groupId) {
@@ -96,6 +102,23 @@ public class ShoppingListService {
 		item.setIsBought(isBought);
 		item = shoppingListItemRepository.save(item);
 		shoppingListItemRepository.flush();
+
+		if (Boolean.TRUE.equals(isBought)) {
+			Long groupId = item.getShoppingList().getGroupId();
+			Pantry pantry = pantryRepository.findAllByGroupId(groupId).stream()
+					.findFirst().orElse(null);
+			if (pantry != null) {
+				pantryService.addItemToPantry(
+						pantry.getId(),
+						item.getIngredient().getId(),
+						item.getQuantity());
+
+				ShoppingList shoppingList = item.getShoppingList();
+				shoppingList.getItems().remove(item);
+				shoppingListItemRepository.delete(item);
+				shoppingListItemRepository.flush();
+			}
+		}
 
 		return item;
 	}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GroupServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GroupServiceTest.java
@@ -1,0 +1,224 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import ch.uzh.ifi.hase.soprafs26.constant.GroupRole;
+import ch.uzh.ifi.hase.soprafs26.entity.Group;
+import ch.uzh.ifi.hase.soprafs26.entity.GroupMembership;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.repository.GroupMembershipRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.GroupRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class GroupServiceTest {
+
+	@Mock
+	private GroupRepository groupRepository;
+	@Mock
+	private GroupMembershipRepository membershipRepository;
+
+	@InjectMocks
+	private GroupService groupService;
+
+	private User testUser;
+	private User testUser2;
+	private Group testGroup;
+	private GroupMembership adminMembership;
+
+	@BeforeEach
+	public void setup() {
+		MockitoAnnotations.openMocks(this);
+
+		testUser = new User();
+		testUser.setUserID("user-1");
+		testUser.setUsername("admin");
+		testUser.setToken("admin-token");
+
+		testUser2 = new User();
+		testUser2.setUserID("user-2");
+		testUser2.setUsername("member");
+		testUser2.setToken("member-token");
+
+		testGroup = new Group();
+		testGroup.setId(1L);
+		testGroup.setName("Test Group");
+		testGroup.setInviteCode("ABC12345");
+		testGroup.setMemberships(new ArrayList<>());
+
+		adminMembership = new GroupMembership();
+		adminMembership.setId(1L);
+		adminMembership.setUser(testUser);
+		adminMembership.setGroup(testGroup);
+		adminMembership.setRole(GroupRole.ADMIN);
+	}
+
+	@Test
+	public void createGroup_validInput_success() {
+		when(membershipRepository.findByUserUserID(testUser.getUserID())).thenReturn(Optional.empty());
+		when(groupRepository.save(any(Group.class))).thenAnswer(i -> { Group g = i.getArgument(0); g.setId(1L); return g; });
+		when(membershipRepository.save(any(GroupMembership.class))).thenAnswer(i -> i.getArgument(0));
+		when(groupRepository.findByInviteCode(any())).thenReturn(Optional.empty());
+
+		Group created = groupService.createGroup(testUser, "My Group");
+		assertNotNull(created);
+		assertEquals("My Group", created.getName());
+	}
+
+	@Test
+	public void createGroup_alreadyInGroup_throwsConflict() {
+		when(membershipRepository.findByUserUserID(testUser.getUserID())).thenReturn(Optional.of(adminMembership));
+		assertThrows(ResponseStatusException.class, () -> groupService.createGroup(testUser, "X"));
+	}
+
+	@Test
+	public void joinGroup_validCode_success() {
+		when(membershipRepository.findByUserUserID(testUser2.getUserID())).thenReturn(Optional.empty());
+		when(groupRepository.findByInviteCode("ABC12345")).thenReturn(Optional.of(testGroup));
+		when(membershipRepository.countByGroupId(1L)).thenReturn(1L);
+		when(membershipRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+		Group joined = groupService.joinGroup(testUser2, "ABC12345");
+		assertEquals(1L, joined.getId());
+	}
+
+	@Test
+	public void joinGroup_invalidCode_throwsNotFound() {
+		when(membershipRepository.findByUserUserID(testUser2.getUserID())).thenReturn(Optional.empty());
+		when(groupRepository.findByInviteCode("BAD")).thenReturn(Optional.empty());
+		assertThrows(ResponseStatusException.class, () -> groupService.joinGroup(testUser2, "BAD"));
+	}
+
+	@Test
+	public void joinGroup_groupFull_throwsConflict() {
+		when(membershipRepository.findByUserUserID(testUser2.getUserID())).thenReturn(Optional.empty());
+		when(groupRepository.findByInviteCode("ABC12345")).thenReturn(Optional.of(testGroup));
+		when(membershipRepository.countByGroupId(1L)).thenReturn(100L);
+		assertThrows(ResponseStatusException.class, () -> groupService.joinGroup(testUser2, "ABC12345"));
+	}
+
+	@Test
+	public void getGroupOfUser_isMember_returnsGroup() {
+		when(membershipRepository.findByUserUserID("user-1")).thenReturn(Optional.of(adminMembership));
+		assertEquals(1L, groupService.getGroupOfUser("user-1").getId());
+	}
+
+	@Test
+	public void getGroupOfUser_notInGroup_throws() {
+		when(membershipRepository.findByUserUserID("user-1")).thenReturn(Optional.empty());
+		assertThrows(ResponseStatusException.class, () -> groupService.getGroupOfUser("user-1"));
+	}
+
+	@Test
+	public void updateGroupName_asAdmin_success() {
+		when(membershipRepository.findByUserUserID("user-1")).thenReturn(Optional.of(adminMembership));
+		when(groupRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+		assertEquals("New", groupService.updateGroupName(testUser, "New").getName());
+	}
+
+	@Test
+	public void updateGroupName_asMember_throwsForbidden() {
+		GroupMembership m = new GroupMembership();
+		m.setUser(testUser2); m.setGroup(testGroup); m.setRole(GroupRole.MEMBER);
+		when(membershipRepository.findByUserUserID("user-2")).thenReturn(Optional.of(m));
+		assertThrows(ResponseStatusException.class, () -> groupService.updateGroupName(testUser2, "New"));
+	}
+
+	@Test
+	public void updateMemberRole_promoteToAdmin_success() {
+		GroupMembership m = new GroupMembership();
+		m.setUser(testUser2); m.setGroup(testGroup); m.setRole(GroupRole.MEMBER);
+		when(membershipRepository.findByUserUserID("user-1")).thenReturn(Optional.of(adminMembership));
+		when(membershipRepository.findByUserUserIDAndGroupId("user-2", 1L)).thenReturn(Optional.of(m));
+		when(membershipRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+		groupService.updateMemberRole(testUser, "user-2", GroupRole.ADMIN);
+		assertEquals(GroupRole.ADMIN, m.getRole());
+	}
+
+	@Test
+	public void updateMemberRole_demoteOnlyAdmin_throws() {
+		when(membershipRepository.findByUserUserID("user-1")).thenReturn(Optional.of(adminMembership));
+		when(membershipRepository.findByUserUserIDAndGroupId("user-1", 1L)).thenReturn(Optional.of(adminMembership));
+		when(membershipRepository.findByGroupId(1L)).thenReturn(Collections.singletonList(adminMembership));
+		assertThrows(ResponseStatusException.class, () -> groupService.updateMemberRole(testUser, "user-1", GroupRole.MEMBER));
+	}
+
+	@Test
+	public void removeMember_success() {
+		GroupMembership m = new GroupMembership();
+		m.setUser(testUser2); m.setGroup(testGroup); m.setRole(GroupRole.MEMBER);
+		when(membershipRepository.findByUserUserID("user-1")).thenReturn(Optional.of(adminMembership));
+		when(membershipRepository.findByUserUserIDAndGroupId("user-2", 1L)).thenReturn(Optional.of(m));
+		groupService.removeMember(testUser, "user-2");
+		verify(membershipRepository).delete(m);
+	}
+
+	@Test
+	public void removeMember_soleAdmin_throws() {
+		when(membershipRepository.findByUserUserID("user-1")).thenReturn(Optional.of(adminMembership));
+		when(membershipRepository.findByUserUserIDAndGroupId("user-1", 1L)).thenReturn(Optional.of(adminMembership));
+		when(membershipRepository.findByGroupId(1L)).thenReturn(Collections.singletonList(adminMembership));
+		assertThrows(ResponseStatusException.class, () -> groupService.removeMember(testUser, "user-1"));
+	}
+
+	@Test
+	public void leaveGroup_asMember_success() {
+		GroupMembership m = new GroupMembership();
+		m.setUser(testUser2); m.setGroup(testGroup); m.setRole(GroupRole.MEMBER);
+		when(membershipRepository.findByUserUserID("user-2")).thenReturn(Optional.of(m));
+		groupService.leaveGroup(testUser2);
+		verify(membershipRepository).delete(m);
+	}
+
+	@Test
+	public void leaveGroup_soleAdminSoleMember_deletesGroup() {
+		when(membershipRepository.findByUserUserID("user-1")).thenReturn(Optional.of(adminMembership));
+		when(membershipRepository.findByGroupId(1L)).thenReturn(Collections.singletonList(adminMembership));
+		when(membershipRepository.countByGroupId(1L)).thenReturn(1L);
+		groupService.leaveGroup(testUser);
+		verify(groupRepository).delete(testGroup);
+	}
+
+	@Test
+	public void leaveGroup_soleAdminWithMembers_throws() {
+		GroupMembership m = new GroupMembership();
+		m.setUser(testUser2); m.setGroup(testGroup); m.setRole(GroupRole.MEMBER);
+		when(membershipRepository.findByUserUserID("user-1")).thenReturn(Optional.of(adminMembership));
+		when(membershipRepository.findByGroupId(1L)).thenReturn(List.of(adminMembership, m));
+		when(membershipRepository.countByGroupId(1L)).thenReturn(2L);
+		assertThrows(ResponseStatusException.class, () -> groupService.leaveGroup(testUser));
+	}
+
+	@Test
+	public void deleteGroup_asAdmin_success() {
+		when(membershipRepository.findByUserUserID("user-1")).thenReturn(Optional.of(adminMembership));
+		groupService.deleteGroup(testUser);
+		verify(groupRepository).delete(testGroup);
+	}
+
+	@Test
+	public void deleteGroup_asMember_throws() {
+		GroupMembership m = new GroupMembership();
+		m.setUser(testUser2); m.setGroup(testGroup); m.setRole(GroupRole.MEMBER);
+		when(membershipRepository.findByUserUserID("user-2")).thenReturn(Optional.of(m));
+		assertThrows(ResponseStatusException.class, () -> groupService.deleteGroup(testUser2));
+	}
+
+	@Test
+	public void regenerateInviteCode_asAdmin_success() {
+		when(membershipRepository.findByUserUserID("user-1")).thenReturn(Optional.of(adminMembership));
+		when(groupRepository.findByInviteCode(any())).thenReturn(Optional.empty());
+		when(groupRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+		Group result = groupService.regenerateInviteCode(testUser);
+		assertNotNull(result.getInviteCode());
+	}
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GroupServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GroupServiceTest.java
@@ -1,11 +1,8 @@
 package ch.uzh.ifi.hase.soprafs26.service;
 
 import ch.uzh.ifi.hase.soprafs26.constant.GroupRole;
-import ch.uzh.ifi.hase.soprafs26.entity.Group;
-import ch.uzh.ifi.hase.soprafs26.entity.GroupMembership;
-import ch.uzh.ifi.hase.soprafs26.entity.User;
-import ch.uzh.ifi.hase.soprafs26.repository.GroupMembershipRepository;
-import ch.uzh.ifi.hase.soprafs26.repository.GroupRepository;
+import ch.uzh.ifi.hase.soprafs26.entity.*;
+import ch.uzh.ifi.hase.soprafs26.repository.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.*;
@@ -26,6 +23,8 @@ public class GroupServiceTest {
 	private GroupRepository groupRepository;
 	@Mock
 	private GroupMembershipRepository membershipRepository;
+	@Mock
+	private ShoppingListRepository shoppingListRepository;
 
 	@InjectMocks
 	private GroupService groupService;
@@ -67,11 +66,13 @@ public class GroupServiceTest {
 		when(membershipRepository.findByUserUserID(testUser.getUserID())).thenReturn(Optional.empty());
 		when(groupRepository.save(any(Group.class))).thenAnswer(i -> { Group g = i.getArgument(0); g.setId(1L); return g; });
 		when(membershipRepository.save(any(GroupMembership.class))).thenAnswer(i -> i.getArgument(0));
+		when(shoppingListRepository.save(any(ShoppingList.class))).thenAnswer(i -> i.getArgument(0));
 		when(groupRepository.findByInviteCode(any())).thenReturn(Optional.empty());
 
 		Group created = groupService.createGroup(testUser, "My Group");
 		assertNotNull(created);
 		assertEquals("My Group", created.getName());
+		verify(shoppingListRepository).save(any(ShoppingList.class));
 	}
 
 	@Test
@@ -184,6 +185,7 @@ public class GroupServiceTest {
 		when(membershipRepository.findByUserUserID("user-1")).thenReturn(Optional.of(adminMembership));
 		when(membershipRepository.findByGroupId(1L)).thenReturn(Collections.singletonList(adminMembership));
 		when(membershipRepository.countByGroupId(1L)).thenReturn(1L);
+		when(shoppingListRepository.findAllByGroupId(1L)).thenReturn(Collections.emptyList());
 		groupService.leaveGroup(testUser);
 		verify(groupRepository).delete(testGroup);
 	}
@@ -201,6 +203,7 @@ public class GroupServiceTest {
 	@Test
 	public void deleteGroup_asAdmin_success() {
 		when(membershipRepository.findByUserUserID("user-1")).thenReturn(Optional.of(adminMembership));
+		when(shoppingListRepository.findAllByGroupId(1L)).thenReturn(Collections.emptyList());
 		groupService.deleteGroup(testUser);
 		verify(groupRepository).delete(testGroup);
 	}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GroupServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GroupServiceTest.java
@@ -25,6 +25,8 @@ public class GroupServiceTest {
 	private GroupMembershipRepository membershipRepository;
 	@Mock
 	private ShoppingListRepository shoppingListRepository;
+	@Mock
+	private PantryRepository pantryRepository;
 
 	@InjectMocks
 	private GroupService groupService;
@@ -67,12 +69,14 @@ public class GroupServiceTest {
 		when(groupRepository.save(any(Group.class))).thenAnswer(i -> { Group g = i.getArgument(0); g.setId(1L); return g; });
 		when(membershipRepository.save(any(GroupMembership.class))).thenAnswer(i -> i.getArgument(0));
 		when(shoppingListRepository.save(any(ShoppingList.class))).thenAnswer(i -> i.getArgument(0));
+		when(pantryRepository.save(any(Pantry.class))).thenAnswer(i -> i.getArgument(0));
 		when(groupRepository.findByInviteCode(any())).thenReturn(Optional.empty());
 
 		Group created = groupService.createGroup(testUser, "My Group");
 		assertNotNull(created);
 		assertEquals("My Group", created.getName());
 		verify(shoppingListRepository).save(any(ShoppingList.class));
+		verify(pantryRepository).save(any(Pantry.class));
 	}
 
 	@Test
@@ -186,6 +190,7 @@ public class GroupServiceTest {
 		when(membershipRepository.findByGroupId(1L)).thenReturn(Collections.singletonList(adminMembership));
 		when(membershipRepository.countByGroupId(1L)).thenReturn(1L);
 		when(shoppingListRepository.findAllByGroupId(1L)).thenReturn(Collections.emptyList());
+		when(pantryRepository.findAllByGroupId(1L)).thenReturn(Collections.emptyList());
 		groupService.leaveGroup(testUser);
 		verify(groupRepository).delete(testGroup);
 	}
@@ -204,6 +209,7 @@ public class GroupServiceTest {
 	public void deleteGroup_asAdmin_success() {
 		when(membershipRepository.findByUserUserID("user-1")).thenReturn(Optional.of(adminMembership));
 		when(shoppingListRepository.findAllByGroupId(1L)).thenReturn(Collections.emptyList());
+		when(pantryRepository.findAllByGroupId(1L)).thenReturn(Collections.emptyList());
 		groupService.deleteGroup(testUser);
 		verify(groupRepository).delete(testGroup);
 	}


### PR DESCRIPTION
Pantry management is handling group access similar to Shopping list; all base actions for the items are the same too.
Item is moved to Pantry when marked as bought in Shopping list (here is point of inter-dependence between Shopping and Pantry)

_addItemToPantry_ is merging potential duplicates (e.g. if one group member adds 2 apples, and second one adds 1 apple as a separate item, they'll me merged into single '3 apples' item); duplicated same logic for shopping list items