### PR TITLE
feat: backend to edit user profile

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/UserController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/UserController.java
@@ -1,5 +1,8 @@
 package ch.uzh.ifi.hase.soprafs26.controller;
 
+import ch.uzh.ifi.hase.soprafs26.entity.Group;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.GroupGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.GroupPostDTO;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -51,7 +54,6 @@ public class UserController {
 		return DTOMapper.INSTANCE.convertEntityToUserGetDTO(user);
 	}
 
-
     @GetMapping("/users/{userID}")
     @ResponseStatus(HttpStatus.OK)
     @ResponseBody
@@ -67,25 +69,23 @@ public class UserController {
         return DTOMapper.INSTANCE.convertEntityToUserGetDTO(requestedUser);
     }
 
-    @PatchMapping("/users/{userID}")
+    @PatchMapping("/users/me")
     @ResponseStatus(HttpStatus.OK)
     @ResponseBody
-    public UserGetDTO patchUserById(@PathVariable("userID") String userID,
-                                    @RequestBody(required = false) UserPostDTO userPostDTO,
+    public UserGetDTO patchUserById(@RequestBody(required = false) UserPostDTO userPostDTO,
                                     Authentication authentication) {
-        User requestedUser = userService.getUserById(userID);
-        if (requestedUser == null) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found");
+        if (authentication == null) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Not authenticated");
         }
         if (!hasAnyUpdateField(userPostDTO)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "At least one field must be provided for update");
         }
 
         String authenticatedUserID = authentication != null ? authentication.getName() : null;
-        authorizationPolicyService.assertCanAccessUser(authenticatedUserID, requestedUser.getUserID(), AccessScope.OWN_USER);
+        authorizationPolicyService.assertCanAccessUser(authenticatedUserID, authentication.getName(), AccessScope.OWN_USER);
 
         User userUpdates = DTOMapper.INSTANCE.convertUserPostDTOtoEntity(userPostDTO);
-        User updatedUser = userService.updateUserById(requestedUser.getUserID(), userUpdates);
+        User updatedUser = userService.updateUserById(authentication.getName(), userUpdates);
         return DTOMapper.INSTANCE.convertEntityToUserGetDTO(updatedUser);
     }
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UserControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UserControllerTest.java
@@ -89,7 +89,7 @@ public class UserControllerTest {
 						&& "new bio".equals(user.getBio())
 						&& UserStatus.ONLINE == user.getStatus()))).willReturn(updatedUser);
 
-		MockHttpServletRequestBuilder postRequest = patch("/users/{userID}", "user-1")
+		MockHttpServletRequestBuilder postRequest = patch("/users/me")
 				.principal(new UsernamePasswordAuthenticationToken("user-1", null))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("{\"email\":\"new@example.com\",\"username\":\"new-username\",\"password\":\"new-password\",\"bio\":\"new bio\",\"status\":\"ONLINE\"}");
@@ -120,7 +120,7 @@ public class UserControllerTest {
 
 		given(userService.getUserById("user-1")).willReturn(existingUser);
 
-		MockHttpServletRequestBuilder request = patch("/users/{userID}", "user-1")
+		MockHttpServletRequestBuilder request = patch("/users/me")
 				.principal(new UsernamePasswordAuthenticationToken("user-1", null))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("{}");

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UserControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UserControllerTest.java
@@ -26,8 +26,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 


### PR DESCRIPTION
This pull request updates the user patch endpoint to improve security and developer experience by allowing authenticated users to update their own profile information via a dedicated `/users/me` endpoint. It also includes minor import cleanups in the controller and test files.

**User Profile Update Endpoint Changes:**

* Changed the user update endpoint from `PATCH /users/{userID}` to `PATCH /users/me`, so authenticated users can only update their own profile, reducing the risk of unauthorized access.
* Updated the authorization logic to use the authenticated user's ID directly, removing the need to pass a user ID in the path and simplifying the code.

**Code Cleanup:**

* Added missing imports for `Group`, `GroupGetDTO`, and `GroupPostDTO` in `UserController.java` to resolve dependency issues.
* Consolidated static imports in `UserControllerTest.java` for cleaner test code.